### PR TITLE
ffda-usb-wan-hotplug: add package

### DIFF
--- a/ffda-usb-wan-hotplug/Makefile
+++ b/ffda-usb-wan-hotplug/Makefile
@@ -1,0 +1,21 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffda-usb-wan-hotplug
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/ffda-usb-wan-hotplug
+  TITLE:=Automatically adds USB ethernet devices to the WAN bridge
+  DEPENDS:=+gluon-core +luaposix +libubus-lua +kmod-usb-net-rndis
+endef
+
+define Package/ffda-usb-wan-hotplug/description
+  Automatically adds USB ethernet devices to the WAN bridge.
+endef
+
+$(eval $(call BuildPackageGluon,ffda-usb-wan-hotplug))

--- a/ffda-usb-wan-hotplug/files/etc/config/usb-wan-hotplug
+++ b/ffda-usb-wan-hotplug/files/etc/config/usb-wan-hotplug
@@ -1,0 +1,2 @@
+config settings 'settings'
+	option enabled '0'

--- a/ffda-usb-wan-hotplug/files/etc/hotplug.d/usb/10-usb-wan-hotplug
+++ b/ffda-usb-wan-hotplug/files/etc/hotplug.d/usb/10-usb-wan-hotplug
@@ -1,0 +1,24 @@
+NETPATH="/sys${DEVPATH}/net"
+LOCKPATH="/tmp/usb-wan-hotplug-devpath"
+
+ENABLED=$(uci get usb-wan-hotplug.settings.enabled)
+MESH_WAN=$(uci get network.mesh_wan.disabled)
+
+if [ "${ACTION}" = "add" ]; then
+	[ "${ENABLED}" != "1" ] && exit 0
+	[ "${MESH_WAN}" != "1" ] && exit 0
+	test -e "${LOCKPATH}" && exit 0
+	if test -e  "${NETPATH}"; then
+		logger -t hotplug "Network USB device was plugged in"
+		echo "${DEVPATH}" > "${LOCKPATH}"
+		usb-wan-hotplug add "${DEVPATH}"
+	fi
+fi
+
+if [ "${ACTION}" = "remove" ]; then
+	if [ "x${DEVPATH}" = "x$(cat ${LOCKPATH})" ]; then
+		logger -t hotplug "Network USB device was removed"
+		usb-wan-hotplug remove "${DEVPATH}"
+		rm "${LOCKPATH}"
+	fi
+fi

--- a/ffda-usb-wan-hotplug/luasrc/usr/bin/usb-wan-hotplug
+++ b/ffda-usb-wan-hotplug/luasrc/usr/bin/usb-wan-hotplug
@@ -1,0 +1,81 @@
+#!/usr/bin/lua
+
+local ubus = require 'ubus'
+local dirent = require "posix.dirent"
+
+BRIDGE_NAME = "wan"
+WAN_IF_PATH = "/tmp/usb-wan-hotplug-wan-interfaces"
+
+ACTION = arg[1]
+DEVPATH = arg[2]
+
+if DEVPATH == nil then return 0 end
+NETPATH="/sys" .. DEVPATH .. "/net"
+
+function get_bridge_interfaces(bridge_name)
+	uconn = ubus.connect()
+	if not uconn then
+		error("failed to connect to ubus")
+	end
+	local status = uconn:call("network.device", "status", {})
+	local ifnames = {}
+	if status["br-" .. bridge_name] ~= nil and status["br-" .. bridge_name]["bridge-members"] ~= nil then
+		for _, ifname in ipairs(status["br-" .. bridge_name]["bridge-members"]) do
+			table.insert(ifnames, ifname)
+		end
+	end
+	ubus.close(uconn)
+	return ifnames
+end
+
+function get_usb_ifname(path)
+	local d = dirent.dir(path)
+	if not d then return nil end
+	for k, v in ipairs(d) do
+		if v ~= "." and v ~= ".." then
+			return v
+		end
+	end
+	return nil
+end
+
+function add_interface_to_bridge(bridge_name, ifname)
+	uconn = ubus.connect()
+	if not uconn then
+		error("failed to connect to ubus")
+	end
+	local status = uconn:call("network.interface." .. bridge_name, "add_device", {name = ifname})
+	ubus.close(uconn)
+	os.execute("ip link set dev " .. ifname .. " up")
+end
+
+function remove_interface_from_bridge(bridge_name, ifname)
+	uconn = ubus.connect()
+	if not uconn then
+		error("failed to connect to ubus")
+	end
+	local status = uconn:call("network.interface." .. bridge_name, "remove_device", {name = ifname})
+	ubus.close(uconn)
+end
+
+if ACTION == "add" then
+	-- Get USB ifname
+	local usb_ifname = get_usb_ifname(NETPATH)
+	if not usb_ifname then return 1 end
+
+	-- Empty WAN bridge
+	local wan_ifnames = get_bridge_interfaces(BRIDGE_NAME)
+	file = io.open(WAN_IF_PATH, "w")
+	for k, v in ipairs(wan_ifnames) do
+		file:write(v, "\n")
+		remove_interface_from_bridge(BRIDGE_NAME, v)
+	end
+	file:close()
+
+	-- Add USB ifname
+	add_interface_to_bridge(BRIDGE_NAME, usb_ifname)
+elseif ACTION == "remove" then
+	for ifname in io.lines(WAN_IF_PATH) do
+		add_interface_to_bridge(BRIDGE_NAME, ifname)
+	end
+end


### PR DESCRIPTION
The usb-wan-hotplug package allows for USB ethernet devices (e.g.
smartphones providing USB tethering) to be used as the WAN interface.