### PR TITLE
ffda-usb-wan-hotplug: add support for tethering iOS

### DIFF
--- a/ffda-usb-wan-hotplug/Makefile
+++ b/ffda-usb-wan-hotplug/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/../package/gluon.mk
 
 define Package/ffda-usb-wan-hotplug
   TITLE:=Automatically adds USB ethernet devices to the WAN bridge
-  DEPENDS:=+gluon-core +luaposix +libubus-lua +kmod-usb-net-rndis
+  DEPENDS:=+gluon-core +luaposix +libubus-lua +kmod-usb-net-rndis +kmod-usb-net-ipheth +usbmuxd
 endef
 
 define Package/ffda-usb-wan-hotplug/description

--- a/ffda-usb-wan-hotplug/files/etc/init.d/gluon-usbmuxd
+++ b/ffda-usb-wan-hotplug/files/etc/init.d/gluon-usbmuxd
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+# Only required for OpenWrt 19.07 and below.
+# usbmuxd ships without it's own init script
+# in those versions.
+
+START=95
+
+USE_PROCD=1
+PROG=/usr/sbin/usbmuxd
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+reload_service() {
+	procd_send_signal $PROG
+}


### PR DESCRIPTION
This adds support for tethering Apple devices.

It uses usbmuxd to query the device for authorizing trust. As OpenWrt 19.07, this package also now contains an initscript for usbmuxd.