### PR TITLE
ffda-gluon-usteer: add package

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -31,6 +31,34 @@ files["**/luasrc/lib/gluon/config-mode/*"] = {
 	},
 }
 
+files["**/check_site.lua"] = {
+	read_globals = {
+		"alternatives",
+		"extend",
+		"in_domain",
+		"in_site",
+		"need",
+		"need_alphanumeric_key",
+		"need_array",
+		"need_array_of",
+		"need_boolean",
+		"need_chanlist",
+		"need_domain_name",
+		"need_number",
+		"need_number_range",
+		"need_one_of",
+		"need_string",
+		"need_string_array",
+		"need_string_array_match",
+		"need_string_match",
+		"need_table",
+		"need_value",
+		"obsolete",
+		"table_keys",
+		"this_domain",
+	},
+}
+
 files["**/luasrc/lib/gluon/**/controller/*"] = {
 	read_globals = {
 		"_",

--- a/ffda-gluon-usteer/Makefile
+++ b/ffda-gluon-usteer/Makefile
@@ -1,0 +1,21 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffda-gluon-usteer
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/ffda-gluon-usteer
+  TITLE:=Gluon integration for the usteer daemon
+  DEPENDS:=+gluon-core +usteer
+endef
+
+define Package/ffda-gluon-usteer/description
+  Gluon integration for the usteer daemon.
+endef
+
+$(eval $(call BuildPackageGluon,ffda-gluon-usteer))

--- a/ffda-gluon-usteer/README.md
+++ b/ffda-gluon-usteer/README.md
@@ -1,0 +1,71 @@
+# ffda-gluon-usteer
+
+This package provides a Gluon-specific integration, the OpenWrt WiFi roaming & steering daemon.
+
+
+## Configuration
+
+This package provides a tiered configuration. It is hard to provide a configuration, which covers all possible deployment environments.
+
+The following configuration options can be configured using the site as well as the `gluon-usteer` configuration package.
+
+
+### network.enabled
+
+Default: 1
+
+Whether usteer contacts adjacent nodes using the mesh-interfaces.
+
+
+### network.wireless
+
+Default: 1
+
+Enabled networking with remote nodes using wireless mesh-interfaces.
+
+
+### network.wired
+
+Default: 1
+
+Enabled networking with remote nodes using wired mesh-interfaces.
+
+
+### network.update_interval
+
+Default: 5
+
+Interval (milliseconds) between node-updates sent.
+
+
+### network.update_timeout
+
+Default: 12
+
+Number of `network.update_interval` intervals after which a remote-node is deleted.
+
+
+### band_steering.enabled
+
+Default: 1
+
+Enables band-steering for clients connected on 2.4 GHz
+
+
+### band_steering.min_snr
+
+Default: -60
+
+Clients require to maintain a SNR / signal better than `band_steering.min_snr` to be steered to 5 GHz.
+
+
+### band_steering.interval
+
+Default: 40
+
+Clients require to maintain `band_steering.min_snr` for `band_steering.interval` milliseconds in order to be steered to 5GHz.
+
+
+## Site configuration
+
+The site configuration provides the site-wide default configuration for usteer.

--- a/ffda-gluon-usteer/check_site.lua
+++ b/ffda-gluon-usteer/check_site.lua
@@ -1,0 +1,14 @@
+-- Network
+
+need_boolean({'usteer', 'network', 'enabled'}, false)
+need_boolean({'usteer', 'network', 'wireless'}, false)
+need_boolean({'usteer', 'network', 'wired'}, false)
+need_number({'usteer', 'network', 'update_interval'}, false)
+need_number({'usteer', 'network', 'update_timeout'}, false)
+
+
+-- Band-Steering
+
+need_boolean({'usteer', 'band_steering', 'enabled'}, false)
+need_number({'usteer', 'band_steering', 'min_snr'}, false)
+need_number({'usteer', 'band_steering', 'interval'}, false)

--- a/ffda-gluon-usteer/files/etc/config/gluon-usteer
+++ b/ffda-gluon-usteer/files/etc/config/gluon-usteer
@@ -1,0 +1,3 @@
+config network network
+
+config band_steering band_steering

--- a/ffda-gluon-usteer/luasrc/lib/gluon/upgrade/750-gluon-usteer
+++ b/ffda-gluon-usteer/luasrc/lib/gluon/upgrade/750-gluon-usteer
@@ -1,0 +1,109 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+
+local wireless = require 'gluon.wireless'
+local site = require 'gluon.site'
+
+
+local defaults = {
+	["network"]={
+		["enabled"]=site.usteer.network.enabled(true),
+		["wireless"]=site.usteer.network.wireless(true),
+		["wired"]=site.usteer.network.wired(true),
+		["update_interval"]=site.usteer.network.update_interval(5000),
+		["update_timeout"]=site.usteer.network.update_timeout(12),
+	},
+	["band_steering"]={
+		["enabled"]=site.usteer.band_steering.enabled(true),
+		["min_snr"]=site.usteer.band_steering.min_snr(-60),
+		["interval"]=site.usteer.band_steering.interval(40000),
+	},
+}
+
+local function get_config(section, option)
+	local default = defaults[section][option]
+	local user = uci:get("gluon-usteer", section, option)
+
+	if user ~= nil and default == true or default == false then
+		user = uci:get_bool("gluon-usteer", section, option)
+	end
+
+	if user ~= nil then
+		return user
+	end
+
+	return default
+end
+
+local function set_config(config, section, option)
+	-- Get config
+	local conf_val = get_config(section, option)
+
+	if conf_val == nil then return end
+
+
+	uci:set('usteer', 'usteer', config, conf_val)
+end
+
+
+uci:delete_all('usteer', 'usteer')
+
+uci:section('usteer', 'usteer', 'usteer', {
+	syslog = 1,
+	ipv6 = 1,
+	debug_level = 2,
+})
+
+
+-- Band steering
+
+if not get_config('band_steering', 'enabled') then
+	uci:set('usteer', 'usteer', 'band_steering_interval', '0')
+else
+	set_config('band_steering_min_snr', 'band_steering', 'min_snr')
+	set_config('band_steering_interval', 'band_steering', 'interval')
+end
+
+
+-- Network
+
+uci:set('usteer', 'usteer', 'local_mode', not get_config('network', 'enabled'))
+
+set_config('remote_update_interval', 'network', 'update_interval')
+set_config('remote_node_timeout', 'network', 'update_timeout')
+
+local networks = {}
+
+if get_config('network', 'wireless') then
+	wireless.foreach_radio(uci, function(radio)
+		local radio_name = radio['.name']
+		table.insert(networks, 'mesh_' .. radio_name)
+	end)
+end
+
+if get_config('network', 'wired') then
+	local prefix = ''
+	if site.mesh.vxlan(true) then
+		prefix = 'vx_'
+	end
+	table.insert(networks, prefix .. 'mesh_lan')
+	table.insert(networks, prefix .. 'mesh_wan')
+end
+
+uci:set('usteer', 'usteer', 'network', networks)
+uci:save('usteer')
+
+
+-- Firewall
+
+uci:section('firewall', 'rule', 'mesh_usteer_ll', {
+	dest_port = 16720,
+	src = 'mesh',
+	name = 'mesh_usteer_ll',
+	src_ip = 'fe80::/64',
+	target = 'ACCEPT',
+	proto = 'udp',
+})
+
+uci:save('firewall')


### PR DESCRIPTION
 # ffda-gluon-usteer

This package provides a Gluon-specific integration, the OpenWrt WiFi roaming & steering daemon.


## Configuration

This package provides a tiered configuration. It is hard to provide a configuration, which covers all possible deployment environments.

The following configuration options can be configured using the site as well as the `gluon-usteer` configuration package.