### PR TITLE
ffda-gluon-usteer: update mesh interface names

### DIFF
--- a/ffda-gluon-usteer/luasrc/lib/gluon/upgrade/750-gluon-usteer
+++ b/ffda-gluon-usteer/luasrc/lib/gluon/upgrade/750-gluon-usteer
@@ -87,8 +87,8 @@ if get_config('network', 'wired') then
 	if site.mesh.vxlan(true) then
 		prefix = 'vx_'
 	end
-	table.insert(networks, prefix .. 'mesh_lan')
-	table.insert(networks, prefix .. 'mesh_wan')
+	table.insert(networks, prefix .. 'mesh_other')
+	table.insert(networks, prefix .. 'mesh_uplink')
 end
 
 uci:set('usteer', 'usteer', 'network', networks)


### PR DESCRIPTION
The mesh-interface were not updated to the new names currently used by Gluon.