### PR TITLE
ffda-gluon-ssh-manager: add package

### DIFF
--- a/ffda-gluon-ssh-manager/Makefile
+++ b/ffda-gluon-ssh-manager/Makefile
@@ -1,0 +1,21 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffda-ssh-manager
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/ffda-ssh-manager
+  TITLE:=Package to provide group-based SSH key management
+  DEPENDS:=+gluon-core
+endef
+
+define Package/ffda-ssh-manager/description
+  Package to provide group-based SSH key management
+endef
+
+$(eval $(call BuildPackageGluon,ffda-ssh-manager))

--- a/ffda-gluon-ssh-manager/README.md
+++ b/ffda-gluon-ssh-manager/README.md
@@ -1,0 +1,65 @@
+# ffda-ssh-manager
+
+This is a utility package which allows communities to add their own key-groups using their site-configuration.
+
+Configuration is done using UCI. The following config-keys exist:
+
+- `ffda-ssh-manager.settings.enabled`
+  - Default: 0
+  - Type: boolean
+  - Enables gluon-ssh-manager.
+- `ffda-ssh-manager.settings.group`
+  - Default: nil
+  - Type: list
+  - Selects the groups to roll out on a node.
+
+ssh-manager will add the group-keys to the end of dropbears `authorized_keys` file.
+This block is identified by a block-start comment. Each key is appended with a comment, associating
+these keys with ssh-manager.
+
+Keys with this trailing comment are removed when they are removed from the key-group or ssh-manager becomes
+disabled.
+
+
+## Defaults
+
+Defaults can be defined in the `site.conf`. These will apply to nodes which are first-time installed or where
+ssh-manager is initially rolled out to.
+
+If you omit default settings from your `site.conf`, ssh-manager will automatically be disabled with no groups
+selected.
+
+
+## Append behvaior
+
+In case a key is defined in multiple activated groups, the key will only be appended once to `authorized_keys`.
+
+In case a key is manually added to `authorized_keys` (Not ending with the ssh-manager comment trailer) and
+the same key is defined in an activated group, the key will still be appended by ssh-manager.
+
+However, the manually added key will persist even when SSH-manager becomes disabled.
+
+
+## Default site-configuration
+
+```
+	ssh_manager = {
+    -- Optional ; Default settings
+		defaults = {
+			enabled = true,
+			groups = {
+				'admins',
+			},
+		},
+		groups = {
+			admins = {
+				'ssh-rsa a01 admin01',
+				'ssh-rsa a02 admin02',
+			},
+			community = {
+				'ssh-rsa c01 community01',
+				'ssh-rsa c02 community02',
+			},
+		},
+	},
+```

--- a/ffda-gluon-ssh-manager/files/etc/config/ffda-ssh-manager
+++ b/ffda-gluon-ssh-manager/files/etc/config/ffda-ssh-manager
@@ -1,0 +1,4 @@
+config settings 'settings'
+#	option enabled '0'
+#	list groups 'admin'
+#	list groups 'user'

--- a/ffda-gluon-ssh-manager/luasrc/lib/gluon/upgrade/860-ffda-ssh-manager
+++ b/ffda-gluon-ssh-manager/luasrc/lib/gluon/upgrade/860-ffda-ssh-manager
@@ -1,0 +1,150 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+local site = require('gluon.site')
+
+local dropbear_key_path = '/etc/dropbear/authorized_keys'
+local ssh_manager_seperator = '# Begin managed keys'
+local ssh_manager_key_trailer = ' # managed key'
+
+local uci_package = 'ffda-ssh-manager'
+local uci_section = 'settings'
+local uci_key_enabled = 'enabled'
+local uci_key_groups = 'groups'
+
+
+local function line_is_trailed_key(line)
+	return string.match(line, ssh_manager_key_trailer .. '$')
+end
+
+local function line_is_seperator(line)
+	return string.match(line, '^' .. ssh_manager_seperator ..  '$')
+end
+
+local function line_is_empty(line)
+	return line == ''
+end
+
+-- Delete all Keys which end with the ssh_manager_key_trailer from the authorized_keys file
+local function delete_managed_keys()
+	local file = io.open(dropbear_key_path, 'r')
+	local lines = {}
+	for line in file:lines() do
+		if not line_is_trailed_key(line) and not line_is_seperator(line) and not line_is_empty(line) then
+			table.insert(lines, line)
+		end
+	end
+	file:close()
+
+	file = io.open(dropbear_key_path, 'w')
+	for _, line in ipairs(lines) do
+		file:write(line, '\n')
+	end
+	file:close()
+end
+
+-- Function to make table values unique
+local function unique(t)
+	local seen = {}
+	local unique_t = {}
+	for _, v in ipairs(t) do
+		if not seen[v] then
+			seen[v] = true
+			table.insert(unique_t, v)
+		end
+	end
+	return unique_t
+end
+
+-- Write all output keys to authorized_keys
+local function write_keys(key_table)
+	local file = io.open(dropbear_key_path, 'a')
+
+	file:write('\n')
+	file:write(ssh_manager_seperator, '\n')
+	for _, key in ipairs(key_table) do
+		file:write(key .. ssh_manager_key_trailer, '\n')
+	end
+	file:close()
+end
+
+-- Get all keys from the groups
+local function get_managed_key_table(groups)
+	-- Need counter because of missing tabe:length
+	local num_group_keys = 0
+	local group_keys = {}
+	for _, group in ipairs(groups) do
+		for site_group_name, site_group_keys in pairs(site.ssh_manager.groups()) do
+			if site_group_name == group then
+				for _, key in ipairs(site_group_keys) do
+					table.insert(group_keys, key)
+					num_group_keys = num_group_keys + 1
+				end
+			end
+		end
+	end
+
+	-- Make table unique
+	group_keys = unique(group_keys)
+
+	return num_group_keys, group_keys
+end
+
+-- Check if the manager is configured
+local function manager_configured()
+	local enabled_set = uci:get(uci_package, uci_section, uci_key_enabled) ~= nil
+	local groups_set = uci:get(uci_package, uci_section, uci_key_groups) ~= nil
+
+	return enabled_set or groups_set
+end
+
+-- Set site defined defaults if not yet defined
+local function site_defaults()
+	local site_default_enabled = site.ssh_manager.default.enabled()
+	local site_default_groups = site.ssh_manager.default.groups()
+
+	-- Only set defaults if not already configured
+	if manager_configured() then
+		return
+	end
+
+	-- Disable if no defaults defined
+	uci:set(uci_package, uci_section, uci_key_enabled, site_default_enabled == true)
+
+	-- Only set groups if defined in site
+	if site_default_groups ~= nil then
+		-- Set groups
+		for _, group in pairs(site_default_groups) do
+			uci:add_list(uci_package, uci_section, uci_key_groups, group)
+		end
+	end
+
+	uci:commit(uci_package)
+end
+
+local function main()
+	local enabled = uci:get_bool(uci_package, uci_section, uci_key_enabled)
+	local groups = uci:get(uci_package, uci_section, uci_key_groups)
+
+	-- Delete all keys managed by ssh-manager regardless of the configuration
+	delete_managed_keys()
+
+	-- Don't continue if ssh-manager is not enabled or no groups are defined
+	if not enabled or groups == nil then
+		return 0
+	end
+
+	-- Get all group keys
+	local num_group_keys, group_keys = get_managed_key_table(groups)
+
+	-- Exit if we have no keys to add
+	if num_group_keys == 0 then
+		return 0
+	end
+
+	-- Append ssh-manager keys to authorized_keys
+	write_keys(group_keys)
+end
+
+site_defaults()
+main()


### PR DESCRIPTION
# ffda-ssh-manager

This is a utility package which allows communities to add their own key-groups using their site-configuration.

Configuration is done using UCI. The following config-keys exist:

- `ffda-ssh-manager.settings.enabled`
  - Default: 0
  - Type: boolean
  - Enables gluon-ssh-manager.
- `ffda-ssh-manager.settings.group`
  - Default: nil
  - Type: list
  - Selects the groups to roll out on a node.

ssh-manager will add the group-keys to the end of dropbears `authorized_keys` file.
This block is identified by a block-start comment. Each key is appended with a comment, associating
these keys with ssh-manager.

Keys with this trailing comment are removed when they are removed from the key-group or ssh-manager becomes
disabled.


## Defaults

Defaults can be defined in the `site.conf`. These will apply to nodes which are first-time installed or where
ssh-manager is initially rolled out to.

If you omit default settings from your `site.conf`, ssh-manager will automatically be disabled with no groups
selected.


## Append behvaior

In case a key is defined in multiple activated groups, the key will only be appended once to `authorized_keys`.

In case a key is manually added to `authorized_keys` (Not ending with the ssh-manager comment trailer) and
the same key is defined in an activated group, the key will still be appended by ssh-manager.

However, the manually added key will persist even when SSH-manager becomes disabled.


## Default site-configuration

```
	ssh_manager = {
    -- Optional ; Default settings
		defaults = {
			enabled = true,
			groups = {
				'admins',
			},
		},
		groups = {
			admins = {
				'ssh-rsa a01 admin01',
				'ssh-rsa a02 admin02',
			},
			community = {
				'ssh-rsa c01 community01',
				'ssh-rsa c02 community02',
			},
		},
	},
```
