### PR TITLE
ffac-eol-wifi: add eol_wifi with configurable ssid

### DIFF
--- a/ffac-eol-ssid/Makefile
+++ b/ffac-eol-ssid/Makefile
@@ -1,0 +1,15 @@
+# This package is based on https://gitlab.karlsruhe.freifunk.net/firmware/packages/-/tree/master/ffka-eol-ssid by Julian Schuh and Simon Terzenbach
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-eol-ssid
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=Changes the SSID for devices with this package. Used to show a deprecation warning in the SSID for unsupported targets
+  DEPENDS:=+gluon-core
+endef
+
+$(eval $(call BuildPackageGluon,ffac-eol-ssid))

--- a/ffac-eol-ssid/README.md
+++ b/ffac-eol-ssid/README.md
@@ -1,0 +1,28 @@
+# ffac-eol-ssid
+
+This package changes the 2.4GHz SSID. It is used to show a deprecation warning in the SSID name for unsupported targets (end-of-life).
+It was created to deprecate devices with 4MB and 32MB RAM.
+
+However it can be used for various deprecation processes of old versions.
+For example the soon to come deprecation of devices with 8MB Flash.
+
+One should update all supported devices to the new gluon version, so that only devices without an update are left at the old version.
+Then one can add the `ffac-eol-ssid` package to the old version and leave a much noticed note in the ssid to switch to a supported device.
+
+
+## Site Configuration
+
+```
+eol_wifi_ssid = 'erneuern.freifunk.net'
+```
+
+## Limitations
+
+As this package was created to migrate older devices, it does not respect 5GHz or OWE radio.
+
+## Credits
+
+This is based on the hard-coded packages from FFMUC and FFKA
+
+- https://github.com/freifunkMUC/gluon-packages/tree/main/ffmuc-eol-ssid/
+- https://gitlab.karlsruhe.freifunk.net/firmware/packages/-/blob/master/ffka-eol-ssid/

--- a/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
+++ b/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
@@ -1,0 +1,22 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site'
+local uci = require('simple-uci').cursor()
+
+-- Get/initialize enabled state
+if site.eol_wifi_ssid() == nil then
+        -- Not applicable
+        os.exit(0)
+end
+
+local eol_wifi_ssid = site.eol_wifi_ssid()
+
+if not uci:get_bool('eol-wifi', 'ssid', 'disabled') then
+        uci:section('eol-wifi', 'ssid', 'ssid', {
+                disabled = false,
+        })
+        uci:save('eol-wifi')
+        -- Change client radio ssid
+        uci:set('wireless', 'client_radio0', 'ssid', eol_wifi_ssid)
+        uci:save('wireless')
+end


### PR DESCRIPTION
The Readme is probably missing here yet, but I would like to get opinions on adding these packages

related packages:
https://gitlab.karlsruhe.freifunk.net/firmware/packages/-/blob/master/ffka-eol-ssid/
https://github.com/freifunkMUC/gluon-packages/tree/main/ffmuc-eol-ssid/