### PR TITLE
ffac-scheduled-sysupgrade: add scheduled sysupgrade package

### DIFF
--- a/ffac-scheduled-sysupgrade/LICENSE
+++ b/ffac-scheduled-sysupgrade/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2023, Florian Maurer
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ffac-scheduled-sysupgrade/Makefile
+++ b/ffac-scheduled-sysupgrade/Makefile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2023 Florian Maurer (FFAC)
+# SPDX-License-Identifier: BSD-2-Clause
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-scheduled-sysupgrade
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=Allows scheduled sysupgrades from a given firmware server
+  DEPENDS:=+gluon-core
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-scheduled-sysupgrade/README.md
+++ b/ffac-scheduled-sysupgrade/README.md
@@ -1,0 +1,49 @@
+---
+title: ffac-scheduled-sysupgrade
+---
+
+This package allows to do as scheduled sysupgrade by first downloading
+the image, then waiting a while before doing the actual update. If all
+routers a doing it this way, one does not have to care about leaf nodes
+updating before their offloader. A switch can be scheduled by a given
+time or will be done if a firmware update is already available for
+*switch_after_existing_mins* minutes. This makes switching configs where
+the site.mk is incompatible easier. If only site.conf changes are
+incompatible, one should use **gluon-scheduled-domain-switch** instead.
+
+In most cases, *ffho-autoupdater-wifi-fallback* can help with the
+update. If the only uplink comes from a mesh-on-WAN/LAN connection,
+which already did the update -this does not help - this package resolves
+these situations.
+
+**Sysupgrade must be compatible with `--ignore-minor-compat-version`.**
+
+Nodes will switch when the defined *switch-time* has passed. In case the
+node was powered off while this was supposed to happen, it might not be
+able to acquire the correct time. If it downloaded a image previously,
+it can still update after a given time.
+
+# site.conf
+
+All those settings have to be defined exclusively in the domain, not the
+site.
+
+scheduled_sysupgrade : optional (needed for domains to switch)
+
+
+    firmware_server :
+    -   server from which updates are fetched
+    switch_after_existing_mins :
+    -   amount of time without reachable gateway to switch unconditionally
+    switch_time :
+    -   UNIX epoch after which domain will be switched
+
+Example:
+
+    scheduled_sysupgrade = {
+      firmware_server = 'http://firmware.freifunk-aachen.de/firmware/download/from-2022.1.x/stable/sysupgrade',
+      switch_time = 1683626400, -- 09.05.2023 - 10:00 UTC
+      switch_after_existing_mins = 120,
+    },
+
+This package is inspired by the gluon-core package `gluon-scheduled-domain-switch`.

--- a/ffac-scheduled-sysupgrade/check_site.lua
+++ b/ffac-scheduled-sysupgrade/check_site.lua
@@ -1,0 +1,5 @@
+if need_table(in_site({'scheduled_sysupgrade'}), nil, false) then
+	need_string(in_site({'scheduled_sysupgrade', 'firmware_server'}))
+	need_number(in_site({'scheduled_sysupgrade', 'switch_after_existing_mins'}))
+	need_number(in_site({'scheduled_sysupgrade', 'switch_time'}))
+end

--- a/ffac-scheduled-sysupgrade/luasrc/lib/gluon/scheduled-sysupgrade/do-sysupgrade
+++ b/ffac-scheduled-sysupgrade/luasrc/lib/gluon/scheduled-sysupgrade/do-sysupgrade
@@ -1,0 +1,58 @@
+#!/usr/bin/lua
+
+local unistd = require 'posix.unistd'
+local util = require 'gluon.util'
+local site = require 'gluon.site'
+
+-- Returns true if node was offline long enough to perform domain switch
+local function switch_after_min_reached()
+	if not unistd.access("/tmp/firmware_available") then
+		return false
+	end
+
+	local switch_after_sec = site.scheduled_sysupgrade.switch_after_existing_mins() * 60
+
+	local current_uptime = util.get_uptime()
+	if current_uptime == nil then
+		return false
+	end
+
+	local f = util.readfile("/tmp/firmware_available")
+	if f == nil then
+		return false
+	end
+	local offline_since = tonumber(f)
+
+	local offline_time_sec = current_uptime - offline_since
+
+	if offline_time_sec > switch_after_sec then
+		return true
+	end
+	return false
+end
+
+-- Returns true in case switch time has passed
+local function switch_time_passed()
+	local current_time = os.time()
+	local switch_time = site.scheduled_sysupgrade.switch_time()
+
+	return switch_time < current_time
+end
+
+if site.scheduled_sysupgrade() == nil then
+	-- Switch not applicable
+	print("No schedule for sysupgrade")
+	os.exit(0)
+end
+
+if not switch_after_min_reached() and not switch_time_passed() then
+	-- Neither switch-time passed nor switch_after_min reached
+	os.exit(0)
+end
+
+
+local success = os.execute("sysupgrade --ignore-minor-compat-version /tmp/firmware.bin")
+
+if success > 0 then
+	os.execute("sysupgrade /tmp/firmware.bin")
+end

--- a/ffac-scheduled-sysupgrade/luasrc/lib/gluon/upgrade/950-gluon-scheduled-domain-switch
+++ b/ffac-scheduled-sysupgrade/luasrc/lib/gluon/upgrade/950-gluon-scheduled-domain-switch
@@ -1,0 +1,18 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site'
+
+local cronfile = "/usr/lib/micron.d/gluon-scheduled-sysupgrade"
+
+-- Check if domain switch is scheduled
+if site.scheduled_sysupgrade() == nil then
+	-- In case no domain switch is scheduled, remove cronfile
+	os.remove(cronfile)
+	os.exit(0)
+end
+
+-- Only in case domain switch is scheduled
+local f = io.open(cronfile, "w")
+f:write("* * * * *  /usr/bin/gluon-check-available\n")
+f:write("*/5 * * * *  /lib/gluon/scheduled-sysupgrade/do-sysupgrade\n")
+f:close()

--- a/ffac-scheduled-sysupgrade/luasrc/usr/bin/gluon-check-available
+++ b/ffac-scheduled-sysupgrade/luasrc/usr/bin/gluon-check-available
@@ -1,0 +1,36 @@
+#!/usr/bin/lua
+
+local unistd = require 'posix.unistd'
+local util = require 'gluon.util'
+local site = require 'gluon.site'
+
+local firmware_flag_file = "/tmp/firmware_available"
+local firmware_available = unistd.access("/tmp/firmware.bin")
+
+-- Check if domain-switch is scheduled
+if site.scheduled_sysupgrade() == nil then
+	-- Switch not applicable
+	os.exit(0)
+end
+
+local firmware_server = site.scheduled_sysupgrade.firmware_server()
+
+if not firmware_available then
+	local exit_code = os.execute("autoupdater -n " .. firmware_server)
+	if exit_code == 0 and unistd.access("/tmp/firmware.bin") then
+		firmware_available = true
+	end
+end
+
+if firmware_available then
+	-- Check if we already have firmware available
+	if unistd.access(firmware_flag_file) then
+		os.exit(0)
+	end
+	-- Create firmware available flag
+	local f = io.open(firmware_flag_file, "w")
+	f:write(tostring(util.get_uptime()))
+	f:close()
+else
+	os.remove(firmware_flag_file)
+end


### PR DESCRIPTION
For upcoming firmware migrations in FFAC I built a package which an downloads the firmware via autoupdater -n and installs it later, so that other nodes can make sure to receive the update before the breaking install happens.

use-case: changes of the site.mk bring incompatibility with the previous firmware, autoupdater-wifi-fallback doesn't help because uplink came via mesh-on-wan (e.g. from nanopi or x86 offloader)

if only the site.conf is affected - one should use scheduled-domain-switch, if the site.mk is also affected, this package should be used for migrations