### PR TITLE
ffac-change-autoupdater: add package to switch autoupdater branch

### DIFF
--- a/ffac-change-autoupdater/LICENSE
+++ b/ffac-change-autoupdater/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2023, Florian Maurer
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ffac-change-autoupdater/Makefile
+++ b/ffac-change-autoupdater/Makefile
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2023 Florian Maurer (FFAC)
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-change-autoupdater
+PKG_VERSION:=1
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Migration script to switch autoupdater on nodes from a branch to a different branch
+  DEPENDS:=+gluon-core
+  MAINTAINER:=Freifunk Aachen <technik@freifunk-aachen.de>
+endef
+
+define Package/$(PKG_NAME)/description
+	Migration script to switch autoupdater on nodes from a branch to a different branch
+endef
+
+define Package/$(PKG_NAME)/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-change-autoupdater/README.md
+++ b/ffac-change-autoupdater/README.md
@@ -1,0 +1,26 @@
+# ffac-change-autoupdater
+
+Change the autoupdater branch after on upgrade.
+This is needed to switch the autoupdater branch after releasing a migration or getting back testing devices to stable.
+
+# Usage
+
+Add the package to the `site.mk` after adding the community-packages repository to `modules`.
+Add the following to the `site.conf`:
+
+```
+update_channel = {
+    --from_name = false, -- remove or false to catch all
+    -- if to_name is defined, autoupdater branch is set to it on upgrade
+    to_name = 'stable',
+
+}
+```
+
+## Related packages
+
+* https://github.com/eulenfunk/packages/tree/v2020.1.x/eulenfunk-migrate-updatebranch
+* https://github.com/freifunkMUC/gluon-packages/tree/main/ffmuc-autoupdater-next2stable
+* https://github.com/freifunkMUC/gluon-packages/tree/main/ffmuc-autoupgrade-experimental2testing
+* https://github.com/freifunkh/ffh-packages/tree/master/ffh-autoupdater-to-stable
+* https://github.com/tecff/gluon-packages/tree/main/tecff-autoupdater-to-stable

--- a/ffac-change-autoupdater/files/lib/gluon/upgrade/505-change-autoupdater
+++ b/ffac-change-autoupdater/files/lib/gluon/upgrade/505-change-autoupdater
@@ -1,0 +1,19 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site'
+local uci = require('simple-uci').cursor()
+
+local branch = uci:get('autoupdater', 'settings', 'branch')
+
+if site.update_channel == nil then
+
+	-- print('update_channel not defined in site.conf')
+else
+    local from_name = site.update_channel.from_name() or false --use any from release
+    local to_name = site.update_channel.to_name() or false
+
+    if to_name and (not from_name or from_name == branch) then
+        uci:set('autoupdater', 'settings', 'branch', to_name)
+    end
+    uci:save('autoupdater')
+end


### PR DESCRIPTION
- configurable through site, see README
- I could have multiple branches implemented as a dict of migrations, but I decided against it, as I did not need this migration and therefore could not test it thoroughly
- tested in ffac

fixes #26 