### PR TITLE
ffac-autoupdater-wifi-fallback: add fallback wifi autoupdater

### DIFF
--- a/ffac-autoupdater-wifi-fallback/LICENSE
+++ b/ffac-autoupdater-wifi-fallback/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2023 kb-light, Patric Steffen, Andreas Ziegler, Florian Maurer
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ffac-autoupdater-wifi-fallback/Makefile
+++ b/ffac-autoupdater-wifi-fallback/Makefile
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 kb-light, Patric Steffen, Andreas Ziegler, Florian Maurer
+# SPDX-License-Identifier: BSD-2-Clause
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-autoupdater-wifi-fallback
+PKG_VERSION:=2
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+PKG_BUILD_DEPENDS := respondd
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=Implements switching to fallback mode if we are cut off from the mesh
+  DEPENDS:=+gluon-autoupdater +gluon-site +gluon-state-check +iw +libgluonutil +libiwinfo-lua +luabitop +luaposix +micrond +wpa-supplicant-mini
+  MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-autoupdater-wifi-fallback/README.md
+++ b/ffac-autoupdater-wifi-fallback/README.md
@@ -1,0 +1,27 @@
+# ffac-autoupdater-wifi-fallback
+
+If a node has no connection to the mesh, neither via wlan-mesh nor via
+mesh-vpn, it ist not possible to update this node via `autoupdater`. Therefor
+the *wifi-fallback* was developed. It checks hourly whether the node is part of
+a fully operative mesh or not. Else the node connects to a visible "Freifunknetz"
+and tries downloads an update as wlan-client via executing `autoupdater -f`.
+
+This is compatible with gluon/openwrt versions >= v2022.x
+
+## /etc/config/autoupdater-wifi-fallback
+
+**autoupdater-wifi-fallback.settings.enabled:**
+- `0` disables the fallback mode
+- `1` enables the fallback mode
+
+### example
+```
+config autoupdater-wifi-fallback 'settings'
+	option enabled '1'
+```
+
+## Credits
+
+This includes gluon-state-check from tecff to be mesh protocol independent.
+As well as using upstream wpa-supplicant-mini to support new version.
+It was formerly created by ffho as `ffho-autoupdater-wifi-fallback`

--- a/ffac-autoupdater-wifi-fallback/files/etc/config/autoupdater-wifi-fallback
+++ b/ffac-autoupdater-wifi-fallback/files/etc/config/autoupdater-wifi-fallback
@@ -1,0 +1,2 @@
+#config autoupdater-wifi-fallback settings
+#	option enabled 1

--- a/ffac-autoupdater-wifi-fallback/luasrc/lib/gluon/upgrade/510-autoupdater-wifi-fallback
+++ b/ffac-autoupdater-wifi-fallback/luasrc/lib/gluon/upgrade/510-autoupdater-wifi-fallback
@@ -1,0 +1,45 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+
+local enabled
+if uci:get('autoupdater-wifi-fallback', 'settings') then
+  enabled = uci:get_bool('autoupdater-wifi-fallback', 'settings', 'enabled')
+  uci:delete('autoupdater-wifi-fallback', 'settings')
+else
+  enabled = uci:get_bool('autoupdater', 'settings', 'enabled')
+end
+
+uci:section('autoupdater-wifi-fallback', 'autoupdater-wifi-fallback', 'settings',{
+  enabled = enabled,
+})
+
+uci:delete('wireless', 'fallback')
+uci:delete('network', 'fallback')
+uci:delete('network', 'fallback6')
+
+uci:section('network', 'interface', 'fallback',{
+  proto = 'dhcp',
+  peerdns = true,
+  sourcefilter = false,
+})
+uci:section('network', 'interface', 'fallback6',{
+  ifname = '@fallback',
+  proto = 'dhcpv6',
+  peerdns = true,
+  sourcefilter = false,
+})
+
+uci:save('autoupdater-wifi-fallback')
+uci:save('network')
+uci:save('wireless')
+
+local file = io.open('/usr/lib/micron.d/autoupdater', 'r')
+local content = file:read "*a"
+local minute = tonumber(content:match('^([0-9][0-9]?)%s'))
+file:close()
+minute = (minute + 10) % 60
+
+local f = io.open('/usr/lib/micron.d/autoupdater-wifi-fallback', 'w')
+f:write(string.format('%i * * * * /usr/sbin/autoupdater-wifi-fallback\n', minute))
+f:close()

--- a/ffac-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
+++ b/ffac-autoupdater-wifi-fallback/luasrc/usr/lib/lua/autoupdater-wifi-fallback/util.lua
@@ -1,0 +1,58 @@
+#!/usr/bin/lua
+local uci = require('simple-uci').cursor()
+local iwinfo = require 'iwinfo'
+local log = require 'posix.syslog'
+local M = {}
+
+function M.log(dest, msg)
+	local prefix = 'autoupdater-wifi-fallback: '
+	msg = prefix .. msg
+	if dest == 'out' then
+		io.stdout:write(msg .. '\n')
+		log.syslog(log.LOG_INFO, msg)
+	elseif dest == 'err' then
+		io.stderr:write(msg .. '\n')
+		log.syslog(log.LOG_CRIT, msg)
+	end
+end
+
+function M.get_available_wifi_networks()
+	local radios = {}
+
+	uci:foreach('wireless', 'wifi-device',
+		function(s)
+			radios[s['.name']] = {}
+		end
+	)
+
+	for radio, _ in pairs(radios) do
+		local wifitype = iwinfo.type(radio)
+		local iw = iwinfo[wifitype]
+		if not iw then
+			return nil
+		end
+		local tmplist = iw.scanlist(radio)
+		for _, net in ipairs(tmplist) do
+			if net.ssid and net.bssid
+			and net.ssid:match('.*[Ff][Rr][Ee][Ii][Ff][Uu][Nn][Kk].*')
+			then
+				table.insert (radios[radio], net)
+			end
+		end
+	end
+
+	return radios
+end
+
+function M.get_update_hosts(branch)
+	local hosts = {}
+	local mirrors = uci:get_list('autoupdater', branch, 'mirror')
+
+	for _, mirror in ipairs(mirrors) do
+		local host = mirror:match('://%[?([a-zA-Z0-9%-%:%.]+)%]?/')
+		table.insert(hosts, 1, host)
+	end
+	return hosts
+end
+
+return M

--- a/ffac-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
+++ b/ffac-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
@@ -1,0 +1,160 @@
+#!/usr/bin/lua
+local uci = require('simple-uci').cursor()
+local autil = require 'autoupdater-wifi-fallback.util'
+local util = require 'gluon.util'
+local bit = require 'bit'
+local fcntl = require 'posix.fcntl'
+local unistd = require 'posix.unistd'
+
+local configname = 'autoupdater-wifi-fallback'
+local lockfilename = '/var/lock/' .. configname .. '.lock'
+local force = false
+local min_uptime_secs = 3600
+local branch_name = uci:get('autoupdater', 'settings', 'branch')
+
+local lockfd, err = fcntl.open(lockfilename, bit.bor(fcntl.O_WRONLY, fcntl.O_CREAT), 384) -- mode 0600
+if not lockfd then
+  autil.log('err', err)
+  local err_verbose = string.format("Unable to get file descriptor for lock file %s .", lockfilename)
+  autil.log('err', err_verbose)
+  os.exit(1)
+end
+
+local ok, _ = fcntl.fcntl(lockfd, fcntl.F_SETLK, {
+  l_start = 0,
+  l_len = 0,
+  l_type = fcntl.F_WRLCK,
+  l_whence = unistd.SEEK_SET,
+})
+if not ok then
+  local err_msg = string.format("Unable to lock file %s. ", lockfilename) ..
+    "Make sure there is no other instance of this script running."
+  autil.log('err', err_msg)
+  os.exit(1)
+end
+
+local function parse_args()
+local i = 1
+  while arg[i] do
+    if arg[i] == '-f' then
+      force = true
+    elseif arg[i] == '-b' then
+      i=i+1
+
+      if not arg[i] then
+        autil.log('err', 'Error parsing command line: expected branch name')
+        os.exit(1)
+      end
+
+      branch_name = arg[i]
+    else
+      autil.log('err', "Error parsing command line: unexpected argument: '" .. arg[i] .. "'")
+      os.exit(1)
+    end
+    i = i+1
+  end
+end
+
+local function preflight_check()
+  if not uci:get_bool(configname, 'settings', 'enabled') then
+    return false
+  end
+  if not uci:get_bool('autoupdater', 'settings', 'enabled') then
+    return false
+  end
+  if tonumber(util.readfile('/proc/uptime'):match('^([^ ]+) ')) < min_uptime_secs then
+    return false
+  end
+
+  return true
+end
+
+local function connectivity_check()
+  -- check if default gateway is set
+  local f = io.open('/var/gluon/state/has_default_gw4', 'r')
+  if f then
+    f:close()
+    return true
+  end
+
+  -- connectivity check against updateserver
+  for _, host in ipairs(autil.get_update_hosts(branch_name)) do
+    if os.execute('ping -w2 -c1 ' .. host .. ' > /dev/null 2>&1') == 0 then
+      return true
+    end
+  end
+
+  autil.log('out', 'connectivity check failed')
+  return false
+end
+
+local function run_autoupdater()
+  autil.log('out', 'executing the autoupdater...')
+  os.execute('/usr/sbin/autoupdater -f -b ' .. branch_name)
+end
+
+local function switch_to_fallback_mode(radio, ssid, bssid)
+  autil.log('out', 'connecting to '  .. radio .. ' ' .. ssid .. ' ' .. bssid)
+  uci:delete_all('wireless', 'wifi-iface')
+  uci:section('wireless', 'wifi-iface', 'fallback', {
+    device = radio,
+    network = 'fallback',
+    mode = 'sta',
+    disabled = false,
+    macaddr = util.generate_mac(3, 10),
+    bssid = bssid,
+    ssid = ssid,
+    ifname = 'fallback',
+    encryption = 'none',
+  })
+  uci:set('wireless', radio, 'disabled', false)
+  uci:save('wireless')
+
+  os.execute('wifi')
+  os.execute('sleep 5')
+  uci:revert('wireless')
+  os.execute('sleep 20')
+end
+
+local function revert_to_standard_mode()
+  autil.log('out', 'going back to standard mode')
+  os.execute('/etc/init.d/network restart')
+  os.execute('sleep 30')
+end
+
+parse_args()
+
+if not uci:get('autoupdater', branch_name) then
+  autil.log('err', 'Cant find configuration for branch: ' .. branch_name)
+  os.exit(1)
+end
+
+if (force or preflight_check()) and not connectivity_check() then
+  local offset = 2 * 3600
+  local unreachable_since = os.time()
+  if not uci:get('autoupdater-wifi-fallback', 'settings', 'unreachable_since') then
+    uci:set(configname, 'settings', 'unreachable_since', unreachable_since)
+  else
+    uci:set(configname, 'settings', 'last_run', unreachable_since)
+    unreachable_since = uci:get(configname, 'settings', 'unreachable_since')
+  end
+  uci:save(configname)
+
+  if force or tonumber(unreachable_since) + offset < os.time() then
+    autil.log('out', 'going to fallback mode')
+    for radio, netlist in pairs(autil.get_available_wifi_networks()) do
+      for _, net in ipairs(netlist) do
+        switch_to_fallback_mode(radio, net.ssid, net.bssid)
+        if run_autoupdater() == 0 then
+          break
+        end
+      end
+    end
+    -- this is only reached if no updated happened
+    revert_to_standard_mode()
+  end
+else
+  uci:delete(configname, 'settings', 'unreachable_since')
+  uci:delete(configname, 'settings', 'last_run')
+  uci:save(configname)
+end

--- a/ffac-autoupdater-wifi-fallback/src/Makefile
+++ b/ffac-autoupdater-wifi-fallback/src/Makefile
@@ -1,0 +1,6 @@
+all: respondd.so
+
+CFLAGS += -Wall
+
+respondd.so: respondd.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared -fPIC -D_GNU_SOURCE -o $@ $^ $(LDLIBS) -lgluonutil -luci

--- a/ffac-autoupdater-wifi-fallback/src/respondd.c
+++ b/ffac-autoupdater-wifi-fallback/src/respondd.c
@@ -1,0 +1,77 @@
+/*
+  Copyright (c) 2016, Matthias Schiffer <mschiffer@universe-factory.net>
+  Copyright (c) 2016, Karsten Böddeker <freifunk@kb-light.de>
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#include <respondd.h>
+
+#include <json-c/json.h>
+
+#include <uci.h>
+
+#include <string.h>
+
+
+static struct json_object * get_autoupdater_wifi_fallback(void) {
+	struct uci_context *ctx = uci_alloc_context();
+	ctx->flags &= ~UCI_FLAG_STRICT;
+
+	struct uci_package *p;
+	if (uci_load(ctx, "autoupdater-wifi-fallback", &p))
+		goto error;
+
+	struct uci_section *s = uci_lookup_section(ctx, p, "settings");
+	if (!s)
+		goto error;
+
+	struct json_object *ret = json_object_new_object();
+
+	const char *enabled = uci_lookup_option_string(ctx, s, "enabled");
+	json_object_object_add(ret, "wifi-fallback", json_object_new_boolean(enabled && !strcmp(enabled, "1")));
+
+	uci_free_context(ctx);
+
+	return ret;
+
+ error:
+	uci_free_context(ctx);
+	return NULL;
+}
+
+static struct json_object * respondd_provider_nodeinfo(void) {
+	struct json_object *ret = json_object_new_object();
+
+	struct json_object *software = json_object_new_object();
+	json_object_object_add(software, "autoupdater", get_autoupdater_wifi_fallback());
+	json_object_object_add(ret, "software", software);
+
+	return ret;
+}
+
+
+const struct respondd_provider_info respondd_providers[] = {
+	{"nodeinfo", respondd_provider_nodeinfo},
+	{}
+};


### PR DESCRIPTION
This is a draft version using `wpa-supplicant-mini` which adds around 220KB to the firmware.
This is needed for the package to be supported in versions 2022.x and greater.

Test worked fine on a o2-6431 box running v2022.1.4