### PR TITLE
ffac-eol-ssid: fix name of eol-ssid uci subsystem

### DIFF
--- a/ffac-eol-ssid/Makefile
+++ b/ffac-eol-ssid/Makefile
@@ -12,4 +12,8 @@ define Package/$(PKG_NAME)
   DEPENDS:=+gluon-core
 endef
 
+define Package/ffac-eol-ssid/conffiles
+/etc/config/eol-ssid
+endef
+
 $(eval $(call BuildPackageGluon,ffac-eol-ssid))

--- a/ffac-eol-ssid/README.md
+++ b/ffac-eol-ssid/README.md
@@ -16,6 +16,10 @@ Then one can add the `ffac-eol-ssid` package to the old version and leave a much
 eol_wifi_ssid = 'erneuern.freifunk.net'
 ```
 
+## Upgrading
+
+This package will migrate uci settings for previous versions of it.
+
 ## Limitations
 
 As this package was created to migrate older devices, it does not respect 5GHz or OWE radio.

--- a/ffac-eol-ssid/files/etc/config/eol-ssid
+++ b/ffac-eol-ssid/files/etc/config/eol-ssid
@@ -1,0 +1,2 @@
+config eol-ssid 'settings'
+        option enabled '1'

--- a/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
+++ b/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
@@ -3,20 +3,27 @@
 local site = require 'gluon.site'
 local uci = require('simple-uci').cursor()
 
+-- migrate older ffac-eol-ssid version with manual eol-wifi.ssid.disabled=1
+if uci:get('eol-wifi', 'ssid') ~= nil then
+    local deprecated_ssid_enabled = not uci:get_bool('eol-wifi', 'ssid', 'disabled')
+    uci:set('eol-ssid', 'settings', 'enabled', deprecated_ssid_enabled)
+    uci:save('eol-ssid')
+    os.remove('/etc/config/eol-wifi')
+end
+
 -- Get/initialize enabled state
 if site.eol_wifi_ssid() == nil then
-        -- Not applicable
-        os.exit(0)
+    -- Not applicable
+    os.exit(0)
+end
+
+-- eol-ssid feature disabled on device
+if not uci:get_bool('eol-ssid', 'settings', 'enabled') then
+    os.exit(0)
 end
 
 local eol_wifi_ssid = site.eol_wifi_ssid()
 
-if not uci:get_bool('eol-wifi', 'ssid', 'disabled') then
-        uci:section('eol-wifi', 'ssid', 'ssid', {
-                disabled = false,
-        })
-        uci:save('eol-wifi')
-        -- Change client radio ssid
-        uci:set('wireless', 'client_radio0', 'ssid', eol_wifi_ssid)
-        uci:save('wireless')
-end
+-- Change client radio ssid
+uci:set('wireless', 'client_radio0', 'ssid', eol_wifi_ssid)
+uci:save('wireless')


### PR DESCRIPTION
Before thie change, the eol-ssid uci subsystem had to be created manually and the uci settings did not show up for this package.