### PR TITLE
ci: use action/checkout@v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,8 @@ jobs:
     name: Lua
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Dependencies
         run: sudo apt-get install lua-check
       - name: Lint Lua
         run: luacheck .
-


### PR DESCRIPTION
Silences node12 warning.

The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/