### PR TITLE
ffac-eol-ssid: rework site configuration

### DIFF
--- a/ffac-eol-ssid/README.md
+++ b/ffac-eol-ssid/README.md
@@ -13,7 +13,10 @@ Then one can add the `ffac-eol-ssid` package to the old version and leave a much
 ## Site Configuration
 
 ```
-eol_wifi_ssid = 'erneuern.freifunk.net'
+eol_ssid = {
+    enabled = true,
+    ssid = 'erneuern.freifunk.net',
+}
 ```
 
 ## Upgrading

--- a/ffac-eol-ssid/check_site.lua
+++ b/ffac-eol-ssid/check_site.lua
@@ -1,0 +1,4 @@
+obsolete({'eol_wifi_ssid'}, 'Use eol_ssid.ssid instead.')
+if need_boolean({'eol_ssid', 'enabled'}, false) then
+    need_string({'eol_ssid', 'ssid'})
+end

--- a/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
+++ b/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
@@ -11,18 +11,13 @@ if uci:get('eol-wifi', 'ssid') ~= nil then
     os.remove('/etc/config/eol-wifi')
 end
 
--- Get/initialize enabled state
-if site.eol_wifi_ssid() == nil then
-    -- Not applicable
-    os.exit(0)
+if not site.eol_ssid.enabled(false) -- disabled for site/domain
+or not uci:get_bool('eol-ssid', 'settings', 'enabled') -- disabled on router
+then
+    os.exit(0) -- do not change SSID
 end
 
--- eol-ssid feature disabled on device
-if not uci:get_bool('eol-ssid', 'settings', 'enabled') then
-    os.exit(0)
-end
-
-local eol_wifi_ssid = site.eol_wifi_ssid()
+local eol_wifi_ssid = site.eol_ssid.ssid()
 
 -- Change client radio ssid
 uci:set('wireless', 'client_radio0', 'ssid', eol_wifi_ssid)


### PR DESCRIPTION
Change "eol_wifi" to "eol_ssid", as the package is called "...-eol-ssid".

Allow toggling the "enabled" boolean per domain/site without the need to touch uci configs.