### PR TITLE
ffac-ssid-changer: make extra logging configurable

### DIFF
--- a/ffac-ssid-changer/README.md
+++ b/ffac-ssid-changer/README.md
@@ -55,6 +55,7 @@ Adapt and add this block to your `site.conf`:
                                 -- toggeling every minute:
       tq_limit_max = 45,        -- upper limit, above that the online SSID will be used
       tq_limit_min = 35         -- lower limit, below that the offline SSID will be used
+      debug_log_enabled = true, -- optional: enable extra debug logs
     },
 
 # Commandline options


### PR DESCRIPTION
Currently, the ffac-ssid-changer is very verbose and causes excessive logging on devices without a WiFi device (e.g. offloaders).

This change makes the logging configurable via uci.