### PR TITLE
ffmuc-ipv6-ra-filter: make filter less verbose

### DIFF
--- a/ffmuc-ipv6-ra-filter/files/lib/gluon/ffmuc-ipv6-ra-filter/ipv6-ra-filter
+++ b/ffmuc-ipv6-ra-filter/files/lib/gluon/ffmuc-ipv6-ra-filter/ipv6-ra-filter
@@ -4,7 +4,7 @@
 set -e
 
 # Check if we need to initialise the ra-filter chain
-if ! ebtables-tiny -L IPV6_RA_FILTER; then
+if ! ebtables-tiny -L IPV6_RA_FILTER > /dev/null; then
 	logger -t ipv6_ra_filter "ebtables chain IPV6_RA_FILTER does not exist"
 	ebtables-tiny -N IPV6_RA_FILTER
 	ebtables-tiny -P IPV6_RA_FILTER DROP


### PR DESCRIPTION
The "ebtables-tiny -L" is called regularly and the output is printed as log messages of micron.d causing unnecessary log spam.