### PR TITLE
ci: add shell linting workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+---
+name: Shell Linting
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '.github/workflows/**'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        # Make sure the action is pinned to a commit, as all reviewdog repos
+        # have hundreds of contributors with write access (breaks easy/often)
+        uses: reviewdog/action-shellcheck@96fa305c16b0f9cc9b093af22dcd09de1c8f1c2d  # v1.19.0
+        with:
+          filter_mode: "file"
+          fail_on_error: true
+          check_all_files_with_shebangs: true


### PR DESCRIPTION
A proposal to add some shell linting as there are quite some shell scripts in this repository.