### PR TITLE
ffac-eol-ssid: enable ssid if uci config is unset

### DIFF
--- a/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
+++ b/ffac-eol-ssid/luasrc/lib/gluon/upgrade/950-eol-ssid-nagger
@@ -12,7 +12,7 @@ if uci:get('eol-wifi', 'ssid') ~= nil then
 end
 
 if not site.eol_ssid.enabled(false) -- disabled for site/domain
-or not uci:get_bool('eol-ssid', 'settings', 'enabled') -- disabled on router
+or uci:get('eol-ssid', 'settings', 'enabled') == 0 -- present & disabled on router
 then
     os.exit(0) -- do not change SSID
 end


### PR DESCRIPTION
Currently, the eol-ssid only is shown if enabled is set to 1. This currently only happens if it was migrated from a previous package and the option was set there as well.

Changing this will send the eol-ssid even if the configuration is empty, i.e. for new devices.