### PR TITLE
ffac-mesh-vpn-wireguard-owrt19: fix all shellcheck issues

### DIFF
--- a/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/busybox sh
+# shellcheck shell=dash
 
-if { set -C; 2>/dev/null >/var/lock/checkuplink.lock; }; then
+if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
 	echo "Lock file exists... exiting"
@@ -9,53 +10,56 @@ fi
 
 interface_linklocal() {
 	# We generate a predictable v6 address
+	local macaddr
 	#local macaddr="$(echo $(uci get network.wg_mesh.private_key | wg pubkey) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
-	local macaddr="$(printf "%s" "$(uci get network.wg_mesh.private_key | wg pubkey)"|md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
-	local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
-	# shellcheck disable=SC2086
+	macaddr="$(printf "%s" "$(uci get network.wg_mesh.private_key | wg pubkey)"|md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
+	local oldIFS="$IFS"; IFS=':'; set -- "$macaddr"; IFS="$oldIFS"
 	echo "fe80::$1$2:$3ff:fe$4:$5$6"
 }
 
 clean_port() {
-	echo "$(echo $1 | sed -r 's/:[0-9]+$|\[|\]//g')"
+	echo "$1" | sed -r 's/:[0-9]+$|\[|\]//g'
 }
 
 check_address_family() {
 local peer_endpoint="$1"
-local gateway="$(clean_port $peer_endpoint)"
+local gateway
+gateway="$(clean_port "$peer_endpoint")"
 # Check if we have a default route for v6 if not fallback to v4
-defgw=$(ip -6 route show table 1 | grep 'default via')
-if [ "$?" -eq "0" ]; then
-	local ipv6="$(gluon-wan nslookup $gateway | grep 'Address [0-9]' | egrep -o '([a-f0-9:]+:+)+[a-f0-9]+')"
-	echo [$ipv6]$(echo $peer_endpoint | egrep -oe :[0-9]+$)
+if ip -6 route show table 1 | grep -q 'default via' > /dev/null
+then
+	local ipv6
+	ipv6="$(gluon-wan nslookup "$gateway" | grep 'Address [0-9]' | grep -E -o '([a-f0-9:]+:+)+[a-f0-9]+')"
+	echo "[$ipv6]$(echo "$peer_endpoint" | grep -E -oe ":[0-9]+$")"
 else
-	local ipv4="$(gluon-wan nslookup $gateway | grep 'Address [0-9]' | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")"
-	echo $ipv4$(echo $peer_endpoint | egrep -oe :[0-9]+$)
+	local ipv4
+	ipv4="$(gluon-wan nslookup "$gateway" | grep 'Address [0-9]' | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")"
+	echo "$ipv4$(echo "$peer_endpoint" | grep -E -oe ":[0-9]+$")"
 fi
 
 }
 
 # Do we already have a private-key? If not generate one
-temp=$(uci get network.wg_mesh.private_key)
-if [ "$?" -ne "0" ]; then
+if uci -q get network.wg_mesh.private_key > /dev/nul;
+then
 	uci set network.wg_mesh=interface
-	uci set network.wg_mesh.private_key=$(wg genkey)
+	uci set network.wg_mesh.private_key="$(wg genkey)"
 	uci commit network
 fi
 
 # Is wireguard enabled?
-if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wireguard.mesh_vpn.enabled)" == "1" ]; then
+if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguard.mesh_vpn.enabled)" = "1" ]; then
 	#We assume we are not connected by default
 	CONNECTED=0
 
 	MESH_VPN_IFACE=$(uci get wireguard.mesh_vpn.iface)
 
 	# Check connectivity to supernode
-	wget http://[$(wg  | grep fe80 | awk '{split($3,A,"/")};{print A[1]}')%$MESH_VPN_IFACE]/  --timeout=5 -O/dev/null -q
-	if [ "$?" -eq "0" ]; then
-		GWMAC=$(batctl gwl | grep \* | awk '{print $2}')
-		batctl ping -c 5 $GWMAC &> /dev/null
-		if [ "$?" -eq "0" ]; then
+	if wget "http://[$(wg  | grep fe80 | awk '{split($3,A,"/")};{print A[1]}')%$MESH_VPN_IFACE]/"  --timeout=5 -O/dev/null -q
+	then
+		GWMAC=$(batctl gwl | awk '/[*]/{print $2}')
+		if batctl ping -c 5 "$GWMAC" > /dev/null 2>&1
+		then
 			CONNECTED=1
 		fi
 	fi
@@ -64,34 +68,33 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 	if [ "$CONNECTED" -ne "1" ]; then
 		logger -t checkuplink "Reconnecting ..."
 		NTP_SERVER=$(uci get system.ntp.server)
-		gluon-wan /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug -p $NTP_SERVER -q
+		gluon-wan /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug -p "$NTP_SERVER" -q
 
 		# TODO use upstream config schema: uci show wireguard | grep =peer | sed "s/[^_]*_\([^=]*\).*/\1/"
 		# Get the number of configured peers and randomly select one
-		NUMBER_OF_PEERS=$(uci -q show wireguard | egrep -ce peer_[0-9]+.endpoint)
+		NUMBER_OF_PEERS=$(uci -q show wireguard | grep -E -ce "peer_[0-9]+.endpoint")
 		set +C
 		if [ -f "/tmp/connect_peer" ] ; then
-			PEER="$(( ($(cat /tmp/connect_peer) % $NUMBER_OF_PEERS) +1 ))"
+			PEER="$(( ($(cat /tmp/connect_peer) % NUMBER_OF_PEERS) +1 ))"
 			logger -t checkuplink "Selected ttt $PEER"
 		else
-			PEER="$(awk -v min=1 -v max=$NUMBER_OF_PEERS 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')"
+			PEER="$(awk -v min=1 -v max="$NUMBER_OF_PEERS" 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')"
 		fi
 		echo "$PEER" > /tmp/connect_peer
-		PEER_PUBLICKEY="$(uci get wireguard.peer_$PEER.public_key)"
 		logger -t checkuplink "Selected peer $PEER"
 
-		endpoint="$(check_address_family "$(uci get wireguard.peer_$PEER.endpoint)")"
+		endpoint="$(check_address_family "$(uci get wireguard.peer_"$PEER".endpoint)")"
 
 		logger -t checkuplink "Connecting to $endpoint"
 
 		# Delete Interfaces
-		ip link set nomaster dev mesh-vpn &> /dev/null
-		ip link delete dev mesh-vpn &> /dev/null
-		ip link del $MESH_VPN_IFACE &> /dev/null
+		ip link set nomaster dev mesh-vpn > /dev/null 2>&1
+		ip link delete dev mesh-vpn > /dev/null 2>&1
+		ip link del "$MESH_VPN_IFACE" > /dev/null 2>&1
 		PUBLICKEY=$(uci get network.wg_mesh.private_key | wg pubkey)
 
 		# Push public key to broker, test for https and use if supported
-		wget -q https://[::1]
+		wget -q "https://[::1]"
 		if [ $? -eq 1 ]; then
 			PROTO=http
 		else
@@ -100,27 +103,27 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 
 		NODENAME=$(uci get system.@system[0].hostname)
 		BROKER=$(uci get wireguard.mesh_vpn.broker)
-		gluon-wan wget -q  -O- --post-data='{"node_name": "'"$NODENAME"'","public_key": "'"$PUBLICKEY"'"}' $PROTO://$BROKER
+		gluon-wan wget -q  -O- --post-data='{"node_name": "'"$NODENAME"'","public_key": "'"$PUBLICKEY"'"}' $PROTO://"$BROKER"
 
 		# Bring up the wireguard interface
-		ip link add dev $MESH_VPN_IFACE type wireguard
-		wg set $MESH_VPN_IFACE fwmark 1
-		uci get network.wg_mesh.private_key | wg set $MESH_VPN_IFACE private-key /proc/self/fd/0
-		ip link set up dev $MESH_VPN_IFACE
+		ip link add dev "$MESH_VPN_IFACE" type wireguard
+		wg set "$MESH_VPN_IFACE" fwmark 1
+		uci get network.wg_mesh.private_key | wg set "$MESH_VPN_IFACE" private-key /proc/self/fd/0
+		ip link set up dev "$MESH_VPN_IFACE"
 
 		# Add link-address and Peer
-		ip address add "$(interface_linklocal "$MESH_VPN_IFACE")"/64 dev $MESH_VPN_IFACE
-		if [ "$endpoint" == "" ]; then
-			endpoint=$(uci get wireguard.peer_$PEER.endpoint)
+		ip address add "$(interface_linklocal "$MESH_VPN_IFACE")"/64 dev "$MESH_VPN_IFACE"
+		if [ "$endpoint" = "" ]; then
+			endpoint=$(uci get wireguard.peer_"$PEER".endpoint)
 		fi
-		gluon-wan wg set $MESH_VPN_IFACE peer $(uci get wireguard.peer_$PEER.public_key) persistent-keepalive 25 allowed-ips fe80::1/128 endpoint $endpoint
+		gluon-wan wg set "$MESH_VPN_IFACE" peer "$(uci get wireguard.peer_"$PEER".public_key)" persistent-keepalive 25 allowed-ips fe80::1/128 endpoint "$endpoint"
 
 		# We need to allow incoming vxlan traffic on mesh iface
 		sleep 10
-		ip6tables -I INPUT 1 -i $MESH_VPN_IFACE -m udp -p udp --dport 4789 -j ACCEPT
+		ip6tables -I INPUT 1 -i "$MESH_VPN_IFACE" -m udp -p udp --dport 4789 -j ACCEPT
 		logger -t checkuplink "vxlan link $(interface_linklocal "$MESH_VPN_IFACE")"
 		# Bring up VXLAN
-		ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" local $(interface_linklocal "$MESH_VPN_IFACE") remote fe80::1 dstport 4789 dev $MESH_VPN_IFACE udp6zerocsumtx udp6zerocsumrx
+		ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" local "$(interface_linklocal "$MESH_VPN_IFACE")" remote fe80::1 dstport 4789 dev "$MESH_VPN_IFACE" udp6zerocsumtx udp6zerocsumrx
 		ip link set up dev mesh-vpn
 
 		sleep 5

--- a/ffac-mesh-vpn-wireguard-openwrt19/gluonShellDiet.sh
+++ b/ffac-mesh-vpn-wireguard-openwrt19/gluonShellDiet.sh
@@ -2,4 +2,4 @@
 
 # This script requires a file as argument in which it will remove all comment lines that start with a hash '#'
 
-sed -i '/^\s*\#[^!].*/d; /^\s*\#$/d' $1
+sed -i '/^\s*\#[^!].*/d; /^\s*\#$/d' "$1"


### PR DESCRIPTION
ShellCheck has no "first class support" for `busbox sh` , but instead relies on the `ash` parsing that in turn uses Debian's `dash` implementation.
So I do (correctly) specify `#!/bin/busybox sh` but then tell shellcheck to also accept dash parsing.

See https://www.shellcheck.net/wiki/SC2187 for more details.