### PR TITLE
fix invalid HTTPS check

### DIFF
--- a/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -91,11 +91,11 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 		PUBLICKEY=$(uci get network.wg_mesh.private_key | wg pubkey)
 
 		# Push public key to broker, test for https and use if supported
-		wget -q https://[::1]
-		if [ $? -eq 1 ]; then
-			PROTO=http
-		else
+		if wget -q "https://[::1]"
+		then
 			PROTO=https
+		else
+			PROTO=http
 		fi
 
 		NODENAME=$(uci get system.@system[0].hostname)

--- a/ffac-wg-registration/files/lib/gluon/wg-registration/registration.sh
+++ b/ffac-wg-registration/files/lib/gluon/wg-registration/registration.sh
@@ -4,11 +4,11 @@ if [ "$(uci get gluon.mesh_vpn.enabled)" == "true" ] || [ "$(uci get gluon.mesh_
         # check if registration has been done since last boot
         if [ ! -f /tmp/WG_REGISTRATION_SUCCESSFUL ]; then
 		# Push public key to broker, test for https and use if supported
-		wget -q https://[::1]
-		if [ $? -eq 1 ]; then
-			PROTO=http
-		else
+		if wget -q "https://[::1]"
+		then
 			PROTO=https
+		else
+			PROTO=http
 		fi
 		PUBLICKEY=$(uci get network.wg_mesh.private_key | wg pubkey)
 		NODENAME=$(uci get system.@system[0].hostname)

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -84,11 +84,12 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 		SEGMENT=$(uci get gluon.core.domain)
 
 		# Push public key to broker, test for https and use if supported
-		wget -q https://[::1]
-		if [ $? -eq 1 ]; then
-			PROTO=http
-		else
+
+		if wget -q "https://[::1]"
+		then
 			PROTO=https
+		else
+			PROTO=http
 		fi
 		gluon-wan wget -q  -O- --post-data='{"domain": "'"$SEGMENT"'","public_key": "'"$PUBLICKEY"'"}' $PROTO://$(uci get wireguard.mesh_vpn.broker)
 		


### PR DESCRIPTION
The old code ran wget and checked only if exit code was '1' and then used HTTP as a fallback.

wget returns several different exit code:
https://www.gnu.org/software/wget/manual/html_node/Exit-Status.html

In case for example an "SSL verification failure." occured (expired certs) the fallback did not trigger and it tried but failed to establish an HTTPS connection.