### PR TITLE
*-mesh-vpn-wireguard-vxlan: improve error handling and other fixes

### DIFF
--- a/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -75,8 +75,11 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 	# If we don't have a connection we try to connect
 	if [ "$CONNECTED" -ne "1" ]; then
 		logger -t checkuplink "Reconnecting ..."
-		NTP_SERVER=$(uci get system.ntp.server)
-		gluon-wan /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug -p "$NTP_SERVER" -q
+		NTP_SERVERS=$(uci get system.ntp.server)
+		# shellcheck disable=SC3060  # busybox sh supports string replacement
+		NTP_SERVERS="${NTP_SERVERS// / -p }"  # each separate NTP server needs to be behind a "-p"
+		# shellcheck disable=SC2086  # we need to expand the list of NTP_SERVERS here
+		gluon-wan /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug -p ${NTP_SERVERS} -q
 
 		# TODO use upstream config schema: uci show wireguard | grep =peer | sed "s/[^_]*_\([^=]*\).*/\1/"
 		# Get the number of configured peers and randomly select one

--- a/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -87,7 +87,6 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 		set +C
 		if [ -f "/tmp/connect_peer" ] ; then
 			PEER="$(( ($(cat /tmp/connect_peer) % NUMBER_OF_PEERS) +1 ))"
-			logger -t checkuplink "Selected ttt $PEER"
 		else
 			PEER="$(awk -v min=1 -v max="$NUMBER_OF_PEERS" 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')"
 		fi

--- a/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffac-mesh-vpn-wireguard-openwrt19/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -1,6 +1,10 @@
 #!/bin/busybox sh
 # shellcheck shell=dash
 
+# fail fast and abort early
+set -eu
+# set -o pipefail # TODO: pipefail needs more rework in the script
+
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
@@ -10,11 +14,15 @@ fi
 
 interface_linklocal() {
 	# We generate a predictable v6 address
-	local macaddr
-	#local macaddr="$(echo $(uci get network.wg_mesh.private_key | wg pubkey) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
-	macaddr="$(printf "%s" "$(uci get network.wg_mesh.private_key | wg pubkey)"|md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
-	local oldIFS="$IFS"; IFS=':'; set -- "$macaddr"; IFS="$oldIFS"
-	echo "fe80::$1$2:$3ff:fe$4:$5$6"
+	local macaddr oldIFS
+	# TODO: investigate why this printf is needed here
+	macaddr="$(printf "%s" "$(uci get network.wg_mesh.private_key | wg pubkey)" | md5sum | sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
+	oldIFS="$IFS"
+	IFS=':'
+	# shellcheck disable=SC2086 # we need to split macaddr here using IFS
+	set -- $macaddr
+	IFS="$oldIFS"
+	echo "fe80::${1}${2}:${3}ff:fe${4}:${5}${6}"
 }
 
 clean_port() {
@@ -22,25 +30,25 @@ clean_port() {
 }
 
 check_address_family() {
-local peer_endpoint="$1"
-local gateway
-gateway="$(clean_port "$peer_endpoint")"
-# Check if we have a default route for v6 if not fallback to v4
-if ip -6 route show table 1 | grep -q 'default via' > /dev/null
-then
-	local ipv6
-	ipv6="$(gluon-wan nslookup "$gateway" | grep 'Address [0-9]' | grep -E -o '([a-f0-9:]+:+)+[a-f0-9]+')"
-	echo "[$ipv6]$(echo "$peer_endpoint" | grep -E -oe ":[0-9]+$")"
-else
-	local ipv4
-	ipv4="$(gluon-wan nslookup "$gateway" | grep 'Address [0-9]' | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")"
-	echo "$ipv4$(echo "$peer_endpoint" | grep -E -oe ":[0-9]+$")"
-fi
+	local peer_endpoint="$1"
+	local gateway
+	gateway="$(clean_port "$peer_endpoint")"
+	# Check if we have a default route for v6 if not fallback to v4
+	if ip -6 route show table 1 | grep -q 'default via'
+	then
+		local ipv6
+		ipv6="$(gluon-wan nslookup "$gateway" | grep 'Address [0-9]' | grep -E -o '([a-f0-9:]+:+)+[a-f0-9]+')"
+		echo "[$ipv6]$(echo "$peer_endpoint" | grep -E -oe ":[0-9]+$")"
+	else
+		local ipv4
+		ipv4="$(gluon-wan nslookup "$gateway" | grep 'Address [0-9]' | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b")"
+		echo "$ipv4$(echo "$peer_endpoint" | grep -E -oe ":[0-9]+$")"
+	fi
 
 }
 
 # Do we already have a private-key? If not generate one
-if uci -q get network.wg_mesh.private_key > /dev/nul;
+if ! uci -q get network.wg_mesh.private_key > /dev/null
 then
 	uci set network.wg_mesh=interface
 	uci set network.wg_mesh.private_key="$(wg genkey)"
@@ -88,14 +96,18 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 		logger -t checkuplink "Connecting to $endpoint"
 
 		# Delete Interfaces
-		ip link set nomaster dev mesh-vpn > /dev/null 2>&1
-		ip link delete dev mesh-vpn > /dev/null 2>&1
-		ip link del "$MESH_VPN_IFACE" > /dev/null 2>&1
+		{
+			ip link set nomaster dev mesh-vpn >/dev/null 2>&1
+			ip link delete dev mesh-vpn >/dev/null 2>&1
+		} || true
+		ip link delete dev "${MESH_VPN_IFACE}" >/dev/null 2>&1 || true
+
 		PUBLICKEY=$(uci get network.wg_mesh.private_key | wg pubkey)
 
 		# Push public key to broker, test for https and use if supported
-		wget -q "https://[::1]"
-		if [ $? -eq 1 ]; then
+		ret=0
+		wget -q "https://[::1]" || ret=$?
+		if [ "$ret" -eq 1 ]; then
 			PROTO=http
 		else
 			PROTO=https
@@ -123,11 +135,15 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 		ip6tables -I INPUT 1 -i "$MESH_VPN_IFACE" -m udp -p udp --dport 4789 -j ACCEPT
 		logger -t checkuplink "vxlan link $(interface_linklocal "$MESH_VPN_IFACE")"
 		# Bring up VXLAN
-		ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" local "$(interface_linklocal "$MESH_VPN_IFACE")" remote fe80::1 dstport 4789 dev "$MESH_VPN_IFACE" udp6zerocsumtx udp6zerocsumrx
+		if ! ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')" local "$(interface_linklocal "$MESH_VPN_IFACE")" remote fe80::1 dstport 4789 dev "$MESH_VPN_IFACE" udp6zerocsumtx udp6zerocsumrx
+		then
+			logger -p err -t checkuplink "Unable to create mesh-vpn interface"
+			exit 2
+		fi
 		ip link set up dev mesh-vpn
 
 		sleep 5
 		# If we have a BATMAN_V env we need to correct the throughput value now
 		batctl hardif mesh-vpn throughput_override 1000mbit;
-		fi
+	fi
 fi

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -1,6 +1,10 @@
 #!/bin/busybox sh
 # shellcheck shell=dash
 
+# fail fast and abort early
+set -eu
+# set -o pipefail # TODO: pipefail needs more rework in the script
+
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
@@ -17,7 +21,7 @@ interface_linklocal() {
 	# shellcheck disable=SC2086 # we need to split macaddr here using IFS
 	set -- $macaddr
 	IFS="$oldIFS"
-	echo "fe80::$1$2:$3ff:fe$4:$5$6"
+	echo "fe80::${1}${2}:${3}ff:fe${4}:${5}${6}"
 }
 
 clean_port() {
@@ -86,15 +90,21 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 		logger -t checkuplink "Connecting to $endpoint"
 
 		# Delete Interfaces
-		ip link set nomaster dev mesh-vpn > /dev/null 2>&1
-		ip link delete dev mesh-vpn > /dev/null 2>&1
-		ip link del "$MESH_VPN_IFACE" > /dev/null 2>&1
+		{
+			ip link set nomaster dev mesh-vpn >/dev/null 2>&1
+			ip link delete dev mesh-vpn >/dev/null 2>&1
+		} || true
+		ip link delete dev "${MESH_VPN_IFACE}" >/dev/null 2>&1 || true
+
 		PUBLICKEY=$(uci get wireguard.mesh_vpn.privatekey | wg pubkey)
 		SEGMENT=$(uci get gluon.core.domain)
 
 		# Push public key to broker, test for https and use if supported
-		wget -q "https://[::1]"
-		if [ $? -eq 1 ]; then
+		ret=0
+		wget -q "https://[::1]" || ret=$?
+		# returns Network Failure =4 if https exists
+		# and Generic Error =1 if no ssl lib available
+		if [ "$ret" -eq 1 ]; then
 			PROTO=http
 		else
 			PROTO=https
@@ -125,7 +135,11 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 		fi
 
 		# Bring up VXLAN
-		ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vpn-vxlan", 3), 16))')" local "$(interface_linklocal "$MESH_VPN_IFACE")" remote "$(uci get wireguard.peer_"$PEER".link_address)" dstport 8472 dev "$MESH_VPN_IFACE"
+		if ! ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vpn-vxlan", 3), 16))')" local "$(interface_linklocal "$MESH_VPN_IFACE")" remote "$(uci get wireguard.peer_"$PEER".link_address)" dstport 8472 dev "$MESH_VPN_IFACE"
+		then
+			logger -p err -t checkuplink "Unable to create mesh-vpn interface"
+			exit 2
+		fi
 		ip link set up dev mesh-vpn
 
 		sleep 5

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -75,8 +75,11 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" = "true" ] || [ "$(uci get wireguar
 	# If we don't have a connection we try to connect
 	if [ "$CONNECTED" -ne "1" ]; then
 		logger -t checkuplink "Reconnecting ..."
-		NTP_SERVER=$(uci get system.ntp.server)
-		gluon-wan /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug -p "$NTP_SERVER" -q
+		NTP_SERVERS=$(uci get system.ntp.server)
+		# shellcheck disable=SC3060  # busybox sh supports string replacement
+		NTP_SERVERS="${NTP_SERVERS// / -p }"  # each separate NTP server needs to be behind a "-p"
+		# shellcheck disable=SC2086  # we need to expand the list of NTP_SERVERS here
+		gluon-wan /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug -p ${NTP_SERVERS} -q
 
 		# Get the number of configured peers and randomly select one
 		NUMBER_OF_PEERS=$(uci -q show wireguard | grep -E -ce "peer_[0-9]+.endpoint")


### PR DESCRIPTION
- set -e, -u and pipefail to make errors more transparent
- rework code with the new -e and -u requirements
- replace `$3ff` with `${3}ff` to be transparent that it is not `${3ff}`
- abort with a log message if mesh-vpn could not be created