### PR TITLE
readme: fix link to SPDX FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After this scheme, a community with the short-handle `ffap` would name their pac
 
 The PKG License should be defined as a SPDX ID. See the SPDX FAQ for more details.
 
-https://spdx.org/ids-how
+[spdx.dev/learn/handling-license-info](https://spdx.dev/learn/handling-license-info/#how)
 
 
 ### Sample Makefile


### PR DESCRIPTION
The link doesn't exist anymore.

What was once there can be seen via archive.org:

https://web.archive.org/web/20191116085527/https://spdx.org/ids-how

The new link offers the same info.