### PR TITLE
ffgraz-config-mode-at-runtime: fix depends on ffgraz-web-model

### DIFF
--- a/ffgraz-config-mode-at-runtime/Makefile
+++ b/ffgraz-config-mode-at-runtime/Makefile
@@ -12,7 +12,7 @@ define Package/ffgraz-config-mode-at-runtime
 	SECTION:=admin
 	CATEGORY:=Administration
 	TITLE:=ffgraz-config-mode-at-runtime
-	DEPEPNDS:= +ffgraz-web-model
+	DEPENDS:= +ffgraz-web-model
 endef
 
 define Package/ffgraz-config-mode-at-runtime/description


### PR DESCRIPTION
There seems to be a misspelling in the Makefile of the community package `ffgraz-config-mode-at-runtime`.