### PR TITLE
ffda-ssh-manager: readme: fix groups settings reference

### DIFF
--- a/ffda-ssh-manager/README.md
+++ b/ffda-ssh-manager/README.md
@@ -8,7 +8,7 @@ Configuration is done using UCI. The following config-keys exist:
   - Default: 0
   - Type: boolean
   - Enables gluon-ssh-manager.
-- `ffda-ssh-manager.settings.group`
+- `ffda-ssh-manager.settings.groups`
   - Default: nil
   - Type: list
   - Selects the groups to roll out on a node.


### PR DESCRIPTION
The setting is called groups not group:

https://github.com/freifunk-gluon/community-packages/blob/1e51133bb64a1f0faddeabded786100e7f37b260/ffda-ssh-manager/luasrc/lib/gluon/upgrade/860-ffda-ssh-manager#L13