### PR TITLE
ffgraz-config-mode-theme-funkfeuer: fix typos

### DIFF
--- a/ffgraz-config-mode-theme-funkfeuer/README.md
+++ b/ffgraz-config-mode-theme-funkfeuer/README.md
@@ -12,4 +12,4 @@ GLUON_SITE_PACKAGES := ffgraz-config-mode-theme-funkfeuer -gluon-config-mode-the
 
 # Update
 
-To update the theme with the latest upstream stylesheet, run `cd ffgraz-config-mode-theme-funkeuer && bash update.sh <path/to/gluon-repo>`
+To update the theme with the latest upstream stylesheet, run `cd ffgraz-config-mode-theme-funkfeuer && bash update.sh <path/to/gluon-repo>`

--- a/ffgraz-config-mode-theme-funkfeuer/sass/gluon.scss
+++ b/ffgraz-config-mode-theme-funkfeuer/sass/gluon.scss
@@ -6,8 +6,8 @@
 
 	sass --sourcemap=none -C -t compressed sass/gluon.scss files/lib/gluon/config-mode/www/static/gluon.css
 
-	When commiting changes to this file make sure to commit the respective
-	changes to the compilid version within the same commit!
+	When committing changes to this file make sure to commit the respective
+	changes to the compiled version within the same commit!
 */
 
 /* Colors adjusted based on the CI from https://download.funkfeuer.at/misc/Funkfeuer-CI/VIguide_FUNKFEUER_last.pdf */


### PR DESCRIPTION
Fix some typos in package `ffgraz-config-mode-theme-funkfeuer`