### PR TITLE
ffmuc-mesh-vpn-wireguard-vxlan: delete gluon save

### DIFF
--- a/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -38,4 +38,3 @@ for name, peer in pairs(site.mesh_vpn.wireguard.peers()) do
 end
 
 uci:save('wireguard')
-uci:save('gluon')


### PR DESCRIPTION
It is not necessary to do a gluon save