### PR TITLE
ffmuc-mesh-vpn-wireguard: only use gluon.mesh_vpn

### DIFF
--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -49,8 +49,8 @@ force_wan_connection() {
 	LD_PRELOAD=libpacketmark.so LIBPACKETMARK_MARK=1 gluon-wan "$@"
 }
 
-
-mesh_vpn_enabled="$(uci get wireguard.mesh_vpn.enabled)"
+# Use the gluon.mesh_vpn.enabled to toggle VPN on/off (set during config mode)
+mesh_vpn_enabled="$(uci get gluon.mesh_vpn.enabled)"
 
 # Some legacy code seem to have used "true" instead of the canonical "1".
 # This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)

--- a/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -3,7 +3,6 @@
 local site = require 'gluon.site'
 local uci = require("simple-uci").cursor()
 
-local wg_enabled = uci:get_bool('wireguard', 'mesh_vpn', 'enabled') or false
 local privkey = uci:get("wireguard", "mesh_vpn", "privatekey") or ""
 
 local function valid_wireguard_key(wireguard_key)
@@ -23,14 +22,14 @@ uci:delete_all('wireguard', 'wireguard', function(peer)
 	return peer.preserve ~= '1'
 end)
 
-local mesh_enabled = uci:get_bool('gluon', 'mesh_vpn', 'enabled') -- default
-	or uci:get_bool('fastd', 'mesh_vpn', 'enabled') --migration
-	or wg_enabled -- specific config
+-- migrate fastd.mesh_vpn nodes to gluon.mesh_vpn
+if not uci:get_bool('gluon', 'mesh_vpn', 'enabled') and uci:get_bool('fastd', 'mesh_vpn', 'enabled') then
+	uci:set('gluon', 'mesh_vpn', 'enabled', true)
+end
 
 uci:section("wireguard", "wireguard", "mesh_vpn", {
 	iface = site.mesh_vpn.wireguard.iface(),
 	broker = site.mesh_vpn.wireguard.broker(),
-	enabled = mesh_enabled,
 	privatekey = privkey,
 })
 


### PR DESCRIPTION
Instead of having a custom wireguard.mesh_vpn.enabled toggle always enable wireguard mesh vpn when gluon.mesh_vpn.enabled is enabled.