### PR TITLE
ffmuc-mesh-vpn-wireguard: move check connectivitiy in function to test twice if node is connected

### DIFF
--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -336,5 +336,5 @@ check_connectivity
 
 if [[ "$CONNECTED" == 0 ]]; then
 	logger -p err -t checkuplink "Failed to connect to $PEER_HOST($PEER_ENDPOINT) - Please check your router firewall settings"
-	exit 0
+	exit 4
 fi

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -181,7 +181,21 @@ use_api_v2() {
 	PEER_ENDPOINT="$(combine_ip_port "$PEER_ADDRESS" "$PEER_PORT")"
 }
 
+check_connectivity() {
+	if wget "http://[$(wg  | grep fe80 | awk '{split($3,A,"/")};{print A[1]}')%$MESH_VPN_IFACE]/"  --timeout=5 -O/dev/null -q
+	then
+		GWMAC=$(batctl gwl | awk '/[*]/{print $2}')
+		if batctl ping -c 5 "$GWMAC" > /dev/null 2>&1
+		then
+			CONNECTED=1
+		fi
+	fi
 
+	if [[ "$CONNECTED" == 1 ]]; then
+		# We have a connection, we are done
+		exit 0
+	fi
+}
 
 
 mesh_vpn_enabled="$(uci get wireguard.mesh_vpn.enabled)"
@@ -213,20 +227,7 @@ CONNECTED=0
 MESH_VPN_IFACE=$(get_site_string mesh_vpn.wireguard.iface)
 
 # Check connectivity to supernode
-
-if wget "http://[$(wg  | grep fe80 | awk '{split($3,A,"/")};{print A[1]}')%$MESH_VPN_IFACE]/"  --timeout=5 -O/dev/null -q
-then
-	GWMAC=$(batctl gwl | awk '/[*]/{print $2}')
-	if batctl ping -c 5 "$GWMAC" > /dev/null 2>&1
-	then
-		CONNECTED=1
-	fi
-fi
-
-if [[ "$CONNECTED" == 1 ]]; then
-	# We have a connection, we are done
-	exit 0
-fi
+check_connectivity
 
 logger -t checkuplink "Reconnecting ..."
 NTP_SERVERS=$(uci get system.ntp.server)
@@ -329,3 +330,11 @@ ip link set up dev mesh-vpn
 sleep 5
 # If we have a BATMAN_V env we need to correct the throughput value now
 batctl hardif mesh-vpn throughput_override 1000mbit;
+
+# Check again if connected
+check_connectivity
+
+if [[ "$CONNECTED" == 0 ]]; then
+	logger -p err -t checkuplink "Failed to connect to $PEER_HOST($PEER_ENDPOINT) - Please check your router firewall settings"
+	exit 0
+fi


### PR DESCRIPTION
To enhance the log output, ensure to test the node's connectivity both at the beginning and at the end. This ensures a comprehensive check, particularly useful when HTTPS requests are permitted but Wireguard connections are blocked


```shell
Mon Apr  1 14:43:18 2024 user.info checkuplink: Loadbalancing enabled.
Mon Apr  1 14:43:18 2024 daemon.err micrond[3459]: Unable to access interface: No such device
Mon Apr  1 14:43:18 2024 user.info checkuplink: Contacting wgkex broker https://broker.ffmuc.net/api/v2/wg/key/exchange
Mon Apr  1 14:43:18 2024 user.info checkuplink: Got data from wgkex broker: {"Endpoint":{"Address":"gw06.ext.ffmuc.net","AllowedIPs":["fe80::2a2:e4ff:fef9:2269"],"Port":"40011","PublicKey":"pkRaUOoLuuHnUt9BEGeKrhF3OMYBPecc0iYkika6uhE="}}
Mon Apr  1 14:43:18 2024 user.debug checkuplink: Successfully parsed wgkex broker data
Mon Apr  1 14:43:18 2024 user.info checkuplink: Connecting to gw06.ext.ffmuc.net([2001:678:ed0:ff00::1]:40011)
Mon Apr  1 14:43:28 2024 daemon.notice netifd: Interface 'mesh_vpn' is enabled
Mon Apr  1 14:43:28 2024 daemon.notice netifd: Network device 'mesh-vpn' link is up
Mon Apr  1 14:43:28 2024 daemon.notice netifd: Interface 'mesh_vpn' has link connectivity
Mon Apr  1 14:43:28 2024 daemon.notice netifd: Interface 'mesh_vpn' is setting up now
Mon Apr  1 14:43:28 2024 daemon.notice netifd: Interface 'mesh_vpn' is now up
Mon Apr  1 14:43:28 2024 user.notice firewall: Reloading firewall due to ifup of mesh_vpn (mesh-vpn)
Mon Apr  1 14:43:28 2024 kern.info kernel: [ 1570.683849] batman_adv: bat0: Adding interface: mesh-vpn
Mon Apr  1 14:43:28 2024 kern.info kernel: [ 1570.685475] batman_adv: bat0: The MTU of interface mesh-vpn is too small (1350) to handle the transport of batman-adv packets. Packets going over this interface will be fragmented on layer2 which could impact the performance. Setting the MTU to 1532 would solve the problem.
Mon Apr  1 14:43:28 2024 kern.info kernel: [ 1570.692024] batman_adv: bat0: Interface activated: mesh-vpn
Mon Apr  1 14:43:38 2024 daemon.err micrond[3459]: Failed to send request: Operation not permitted
Mon Apr  1 14:43:38 2024 user.err checkuplink: Failed to connect to gw06.ext.ffmuc.net([2001:678:ed0:ff00::1]:40011) - Please check your router firewall settings
```