### PR TITLE
ffmuc-mesh-vpn-wireguard: Cleanup Code

### DIFF
--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -112,7 +112,7 @@ is_loadbalancing_enabled() {
 }
 
 get_wgkex_data() {
-	local version user_agent 
+	local version user_agent
 	version="$1"
 	WGKEX_BROKER="$PROTO://$WGKEX_BROKER_BASE_PATH/api/$version/wg/key/exchange"
 	user_agent=$(lua /lib/gluon/gluon-mesh-wireguard-vxlan/get-user-agent-infos.lua)

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -18,6 +18,7 @@ else
 	exit
 fi
 
+# start function section
 get_site_string() {
 	local path="$1"
 
@@ -186,6 +187,8 @@ is_connected() {
 	fi
 	return 1 # false
 }
+# end function section
+
 
 # Some legacy code seem to have used "true" instead of the canonical "1".
 # This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -4,6 +4,20 @@
 set -eu
 # set -o pipefail # TODO: pipefail needs more rework in the script
 
+mesh_vpn_enabled="$(uci get wireguard.mesh_vpn.enabled)"
+
+if [[ "${mesh_vpn_enabled}" == "0" ]]; then
+	# Stop the script if mesh_vpn is disabled
+	exit 0
+fi
+
+# Some legacy code seem to have used "true" instead of the canonical "1".
+# This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
+if [[ "${mesh_vpn_enabled}" != "0" ]] && [[ "${mesh_vpn_enabled}" != "1" ]]; then
+	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
+	mesh_vpn_enabled="1"
+fi
+
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
@@ -179,20 +193,6 @@ is_connected() {
 	fi
 	return 1 # false
 }
-
-mesh_vpn_enabled="$(uci get wireguard.mesh_vpn.enabled)"
-
-# Some legacy code seem to have used "true" instead of the canonical "1".
-# This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
-if [[ "${mesh_vpn_enabled}" != "0" ]] && [[ "${mesh_vpn_enabled}" != "1" ]]; then
-	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
-	mesh_vpn_enabled="1"
-fi
-
-if [[ "${mesh_vpn_enabled}" == "0" ]]; then
-	# Stop the script if mesh_vpn is disabled
-	exit 0
-fi
 
 # Do we already have a private-key? If not generate one
 if ! uci -q get wireguard.mesh_vpn.privatekey > /dev/null

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -18,12 +18,6 @@ else
 	exit
 fi
 
-# Some legacy code seem to have used "true" instead of the canonical "1".
-# This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
-if [[ "${mesh_vpn_enabled}" != "1" ]]; then
-	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
-fi
-
 get_site_string() {
 	local path="$1"
 
@@ -192,6 +186,12 @@ is_connected() {
 	fi
 	return 1 # false
 }
+
+# Some legacy code seem to have used "true" instead of the canonical "1".
+# This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
+if [[ "${mesh_vpn_enabled}" != "1" ]]; then
+	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
+fi
 
 # Do we already have a private-key? If not generate one
 if ! uci -q get wireguard.mesh_vpn.privatekey > /dev/null

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -151,13 +151,13 @@ use_api_v1() {
 
 	logger -p info -t checkuplink "Selected peer $PEER"
 	PEER_HOSTPORT="$(uci get wireguard.peer_"$PEER".endpoint)"
-	PEER_HOST="$(clean_port "$PEER_HOSTPORT")"
-	PEER_ADDRESS="$(resolve_host "$PEER_HOST")"
-	PEER_PORT="$(extract_port "$PEER_HOSTPORT")"
-	PEER_ENDPOINT="$(combine_ip_port "$PEER_ADDRESS" "$PEER_PORT")"
 
+	PEER_HOST="$(clean_port "$PEER_HOSTPORT")"
+	PEER_PORT="$(extract_port "$PEER_HOSTPORT")"
 	PEER_PUBLICKEY="$(uci get wireguard.peer_"$PEER".publickey)"
 	PEER_LINKADDRESS="$(uci get wireguard.peer_"$PEER".link_address)"
+	PEER_ADDRESS="$(resolve_host "$PEER_HOST")"
+	PEER_ENDPOINT="$(combine_ip_port "$PEER_ADDRESS" "$PEER_PORT")"
 }
 
 use_api_v2() {
@@ -172,11 +172,11 @@ use_api_v2() {
 	fi
 
 	logger -p debug -t checkuplink "Successfully parsed wgkex broker data"
+	
 	PEER_HOST="$(echo "$data" | sed -n 1p)"
 	PEER_PORT="$(echo "$data" | sed -n 2p)"
 	PEER_PUBLICKEY="$(echo "$data" | sed -n 3p)"
 	PEER_LINKADDRESS=$(echo "$data" | sed -n 4p)
-
 	PEER_ADDRESS="$(resolve_host "$PEER_HOST")"
 	PEER_ENDPOINT="$(combine_ip_port "$PEER_ADDRESS" "$PEER_PORT")"
 }

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -14,7 +14,7 @@ fi
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
-	logger -p err -t checkuplink "Lock file exists... exiting."
+	logger -p notice -t checkuplink "Lock file exists... exiting."
 	exit
 fi
 

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -18,7 +18,6 @@ else
 	exit
 fi
 
-# start function section
 get_site_string() {
 	local path="$1"
 
@@ -187,8 +186,8 @@ is_connected() {
 	fi
 	return 1 # false
 }
-# end function section
 
+# start main logic
 
 # Some legacy code seem to have used "true" instead of the canonical "1".
 # This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -20,7 +20,7 @@ fi
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
-	echo "Lock file exists... exiting"
+	logger -p err -t checkuplink "Lock file exists... exiting."
 	exit
 fi
 
@@ -235,7 +235,7 @@ set +o pipefail # Disable pipefail: this script does not fully support pipefail 
 # shellcheck disable=SC2086 # otherwise ntpd cries
 if ! force_wan_connection /usr/sbin/ntpd -n -N -S /usr/sbin/ntpd-hotplug ${NTP_SERVERS_ADDRS} -q
 then
-	logger -p err -t checkuplink "Unable to establish NTP connection to ${NTP_SERVERS}."
+	logger -p err -t checkuplink "Unable to establish NTP connection to ${NTP_SERVERS}... exiting."
 	exit 3
 fi
 
@@ -301,7 +301,7 @@ fi
 # Bring up VXLAN
 if ! ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vpn-vxlan", 3), 16))')" local "${LINKLOCAL}" remote "$PEER_LINKADDRESS" dstport 8472 dev "$MESH_VPN_IFACE"
 then
-	logger -p err -t checkuplink "Unable to create mesh-vpn interface"
+	logger -p err -t checkuplink "Unable to create mesh-vpn interface... exiting."
 	exit 2
 fi
 ip link set up dev mesh-vpn
@@ -312,7 +312,7 @@ batctl hardif mesh-vpn throughput_override 1000mbit;
 
 # Check again if connected
 if ! is_connected; then
-	logger -p err -t checkuplink "Failed to connect to $PEER_HOST($PEER_ENDPOINT) - Please check your router firewall settings"
+	logger -p err -t checkuplink "Failed to connect to $PEER_HOST($PEER_ENDPOINT) - Please check your router firewall settings... exiting."
 	exit 4
 fi
 

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -104,8 +104,7 @@ is_loadbalancing_enabled() {
 	return 0
 }
 
-
-get_wgkex_data(){
+get_wgkex_data() {
 	local version user_agent 
 	version="$1"
 	WGKEX_BROKER="$PROTO://$WGKEX_BROKER_BASE_PATH/api/$version/wg/key/exchange"
@@ -121,7 +120,7 @@ get_wgkex_data(){
 	fi
 }
 
-use_api_v1(){
+use_api_v1() {
 	WGKEX_DATA=$(get_wgkex_data v1)
 
 	# Parse the returned JSON in a Lua script
@@ -147,8 +146,6 @@ use_api_v1(){
 	PEER_PUBLICKEY="$(uci get wireguard.peer_"$PEER".publickey)"
 	PEER_LINKADDRESS="$(uci get wireguard.peer_"$PEER".link_address)"
 }
-
-
 
 use_api_v2() {
 	WGKEX_DATA=$(get_wgkex_data v2)
@@ -183,7 +180,6 @@ is_connected() {
 	return 1 # false
 }
 
-
 mesh_vpn_enabled="$(uci get wireguard.mesh_vpn.enabled)"
 
 # Some legacy code seem to have used "true" instead of the canonical "1".
@@ -198,7 +194,6 @@ if [[ "${mesh_vpn_enabled}" == "0" ]]; then
 	exit 0
 fi
 
-
 # Do we already have a private-key? If not generate one
 if ! uci -q get wireguard.mesh_vpn.privatekey > /dev/null
 then
@@ -206,9 +201,7 @@ then
 	uci commit wireguard
 fi
 
-
 MESH_VPN_IFACE=$(get_site_string mesh_vpn.wireguard.iface)
-
 
 # Check connectivity to supernode
 if is_connected; then

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -11,17 +11,17 @@ if [[ "${mesh_vpn_enabled}" == "0" ]]; then
 	exit 0
 fi
 
-# Some legacy code seem to have used "true" instead of the canonical "1".
-# This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
-if [[ "${mesh_vpn_enabled}" != "1" ]]; then
-	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
-fi
-
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then
 	trap "rm -f /var/lock/checkuplink.lock" EXIT
 else
 	logger -p err -t checkuplink "Lock file exists... exiting."
 	exit
+fi
+
+# Some legacy code seem to have used "true" instead of the canonical "1".
+# This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
+if [[ "${mesh_vpn_enabled}" != "1" ]]; then
+	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
 fi
 
 get_site_string() {

--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -13,9 +13,8 @@ fi
 
 # Some legacy code seem to have used "true" instead of the canonical "1".
 # This should be overwritten by a gluon-reconfigure (see 400-mesh-vpn-wireguard)
-if [[ "${mesh_vpn_enabled}" != "0" ]] && [[ "${mesh_vpn_enabled}" != "1" ]]; then
+if [[ "${mesh_vpn_enabled}" != "1" ]]; then
 	logger -p warn -t checkuplink "Invalid value for wireguard.mesh_vpn.enabled detected: '${mesh_vpn_enabled}'. Assuming enabled."
-	mesh_vpn_enabled="1"
 fi
 
 if { set -C; true 2>/dev/null >/var/lock/checkuplink.lock; }; then


### PR DESCRIPTION
# Cleanup Code

- Move code Up for early exiting
- remove unnessery code
- aline v1 code with v2 code (same order)
- remove/add some spaces
- add Info About exiting to loggers (if the scritps exist afterwards)
- move echo to logger (or should it be a echo?)