### PR TITLE
ffda-node-whisperer: add package

### DIFF
--- a/ffda-node-whisperer/Makefile
+++ b/ffda-node-whisperer/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffda-node-whisperer
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/blocktrron/node-whisperer.git
+PKG_SOURCE_DATE:=2024-04-10
+PKG_SOURCE_VERSION:=d449a4843a17e64e27c097fe6ed2a4fd54a75d7a
+PKG_MIRROR_HASH:=91af33b88b35496cb0828d5a1418111aede8c3dc64fb3b0b0d4c731d579b633d
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(TOPDIR)/../package/gluon.mk
+
+MAKE_PATH:=src
+MAKE_VARS += \
+	NL_LIB="libnl-tiny" \
+	NL_GENL_LIB="libnl-tiny"
+
+Build/Compile=$(call Build/Compile/Default)
+
+define Package/ffda-node-whisperer
+  TITLE:=Package to provide diagnostic information using WiFi beacons
+  DEPENDS:=+gluon-core +libubox +libubus +libblobmsg-json +libnl-tiny +libbatadv +libgluonutil
+endef
+
+define Package/ffda-node-whisperer/description
+  Package to provide diagnostic information using WiFi beacons
+endef
+
+define Package/ffda-node-whisperer/conffiles
+/etc/config/node-whisperer
+endef
+
+define Package/ffda-node-whisperer/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d $(1)/etc/config $(1)/lib/gluon/upgrade
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/node-whisperer $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/node-whisperer/files/node-whisperer.init $(1)/etc/init.d/node-whisperer
+	$(CP) $(PKG_BUILD_DIR)/openwrt/node-whisperer/files/node-whisperer.uci $(1)/etc/config/node-whisperer
+	$(INSTALL_BIN) ./files/node-whisperer.upgrade.lua $(1)/lib/gluon/upgrade/150-node-whisperer
+endef
+
+$(eval $(call BuildPackageGluon,ffda-node-whisperer))

--- a/ffda-node-whisperer/README.md
+++ b/ffda-node-whisperer/README.md
@@ -1,0 +1,6 @@
+# ffda-node-whisperer
+
+This program encodes information about the status of a Gluon Node
+into the beacons of the wireless client networks.
+This information can be decoded and sent to a community using
+a companion app called [NodeMonitor](https://github.com/blocktrron/NodeMonitor).

--- a/ffda-node-whisperer/check_site.lua
+++ b/ffda-node-whisperer/check_site.lua
@@ -1,0 +1,13 @@
+local information = {
+	'hostname',
+	'node_id',
+	'uptime',
+	'site_code',
+	'domain',
+	'system_load',
+	'firmware_version',
+	'batman_adv'
+}
+
+need_boolean({'node_whisperer', 'enabled'}, false)
+need_array_of({'node_whisperer', 'information'}, information, false)

--- a/ffda-node-whisperer/files/node-whisperer.upgrade.lua
+++ b/ffda-node-whisperer/files/node-whisperer.upgrade.lua
@@ -1,0 +1,37 @@
+#!/usr/bin/lua5.1
+
+local site = require 'gluon.site'
+local uci = require('simple-uci').cursor()
+
+local default_sources = {
+    'hostname',
+    'node_id',
+    'uptime',
+    'site_code',
+    'system_load',
+    'firmware_version',
+}
+
+local sources = {}
+local disabled = false
+local sources_set = false
+
+if not site.node_whisperer.enabled(false) then
+    disabled = true
+end
+
+for _, information in ipairs(site.node_whisperer.information({})) do
+    table.insert(sources, information)
+    sources_set = true
+end
+
+if not sources_set then
+    sources = default_sources
+end
+
+uci:delete('node-whisperer', 'settings')
+uci:section('node-whisperer', 'settings', 'settings', {
+    disabled = disabled,
+})
+uci:set('node-whisperer', 'settings', 'information', sources)
+uci:commit('node-whisperer')


### PR DESCRIPTION
This program encodes information about the status of a Gluon Node into the beacons of the wireless client networks.
This information can be decoded and sent to a community using a companion app called [NodeMonitor](https://github.com/blocktrron/NodeMonitor).