### PR TITLE
ffac-ssid-changer: switch to ubus call to reload hostapd and fix OWE offline ssid

### DIFF
--- a/ffac-ssid-changer/shsrc/ssid-changer.sh
+++ b/ffac-ssid-changer/shsrc/ssid-changer.sh
@@ -216,8 +216,9 @@ elif [ "$CHECK" -eq 0 ]; then
 fi
 
 if [ $HUP_NEEDED = 1 ]; then
-	# send HUP to all hostapd to load the new SSID
-	killall -HUP hostapd
+	# HUP does not work with openwrt-23.05 somehow, use ubus reload
+	# to load the new SSID
+	ubus call hostapd reload
 	## check for nonmatching hostapd-pidfiles
 	if [ -f /lib/gluon/eulenfunk-hotfix/check_hostapd.sh ] ; then
 	   sleep 2 # settle down

--- a/ffac-ssid-changer/shsrc/ssid-changer.sh
+++ b/ffac-ssid-changer/shsrc/ssid-changer.sh
@@ -19,7 +19,7 @@ SETTINGS_DEBUG_LOGGING="$(uci -q get ssid-changer.settings.debug_log_enabled)"
 pgrep -f autoupdater >/dev/null && safety_exit 'autoupdater running'
 UT=$(sed 's/\..*//g' /proc/uptime)
 [ "$UT" -gt 60 ] || safety_exit 'less than one minute'
-[ "$(find /var/run -name "hostapd-phy*" | wc -l)" -gt 0 ] || safety_exit 'no hostapd-phy*'
+[ "$(find /var/run -name "hostapd-*" | wc -l)" -gt 0 ] || safety_exit 'no hostapd-*'
 
 # only once every timeframe minutes the SSID will change to the Offline-SSID
 # (set to 1 minute to change immediately every time the router gets offline)
@@ -132,8 +132,8 @@ if [ "$CHECK" -gt 0 ] || [ "$DISABLED" = '1' ]; then
 	log_debug "node is online"
 	LOOP=1
 	# check status for all physical devices
-	for HOSTAPD in /var/run/hostapd-phy*; do
-		[ -e "$HOSTAPD" ] || break  # handle the case of no hostapd-phy* files
+	for HOSTAPD in /var/run/hostapd-*; do
+		[ -e "$HOSTAPD" ] || break  # handle the case of no hostapd-* files
 		# shellcheck disable=SC2086 # ONLINE_SSIDs has multiple lines
 		ONLINE_SSID="$(echo $ONLINE_SSIDs | awk -F '~' -v l=$((LOOP*2)) '{print $l}')"
 		LOOP=$((LOOP+1))
@@ -178,8 +178,8 @@ elif [ "$CHECK" -eq 0 ]; then
 		if [ "$OFF_COUNT" -ge $((T / 2)) ]; then
 			# node was offline more times than half of switch_timeframe (or than $FIRST)
 			LOOP=1
-			for HOSTAPD in /var/run/hostapd-phy*; do
-				[ -e "$HOSTAPD" ] || break  # handle the case of no hostapd-phy* files
+			for HOSTAPD in /var/run/hostapd-*; do
+				[ -e "$HOSTAPD" ] || break  # handle the case of no hostapd-* files
 				# shellcheck disable=SC2086 # ONLINE_SSIDs has multiple lines
 				ONLINE_SSID="$(echo $ONLINE_SSIDs | awk -F '~' -v l=$((LOOP*2)) '{print $l}')"
 				LOOP=$((LOOP+1))

--- a/ffac-ssid-changer/shsrc/ssid-changer.sh
+++ b/ffac-ssid-changer/shsrc/ssid-changer.sh
@@ -198,7 +198,7 @@ elif [ "$CHECK" -eq 0 ]; then
 					logger -s -t "ffac-ssid-changer" -p 5 "could not set to offline state: did neither find SSID '$ONLINE_SSID' nor '$OFFLINE_SSID'. Please reboot"
 				fi
 				if [ "$OWE" = true ]; then
-					CURRENT_SSID_OWE="$(grep "^ssid=$OFFLINE_SSID_OWE" "$HOSTAPD" | cut -d"=" -f2)"
+					CURRENT_SSID_OWE="$(grep "^ssid=$ONLINE_SSID_OWE" "$HOSTAPD" | cut -d"=" -f2)"
 					if [ "$CURRENT_SSID_OWE" = "$ONLINE_SSID_OWE" ]; then
 						# set offline
 						logger -s -t "ffac-ssid-changer" -p 5 "$MSG""$OFF_COUNT times offline, SSID is $CURRENT_SSID_OWE, change to $OFFLINE_SSID_OWE"


### PR DESCRIPTION
not yet fully tested, but this should include hotfixes to solve:

### fix copy paste mistake in ONLINE_SSID_OWE

use correct ONLINE_SSID_OWE to set offline state for OWE as well

this still does not work with transition mode

fixes #113 

### fix reload of wifi config using ubus

until a fix based on https://github.com/freifunk-gluon/gluon/pull/3223 is available

use ubus call hostapd reload instead of broken HUP

fixes #93 

### fix for radio named wl

don't rely on hostapd radio name starting with phy

some devices have a radio named wl0 and wl1 instead in openwrt 23.05
This is a workaround, until a better fix using lua is available

fixes #39



until a better version of the ssid-changer will be available