### PR TITLE
ffac-ssid-changer: silence grep command

### DIFF
--- a/ffac-ssid-changer/shsrc/ssid-changer.sh
+++ b/ffac-ssid-changer/shsrc/ssid-changer.sh
@@ -134,7 +134,7 @@ if [ "$CHECK" -gt 0 ] || [ "$DISABLED" = '1' ]; then
 	# check status for all physical devices
 	for HOSTAPD in /var/run/hostapd-*.conf; do
 		[ -e "$HOSTAPD" ] || break  # handle the case of no hostapd-* files
-		grep "^bridge=br-client" "$HOSTAPD" || break # handle case of private wifi
+		grep "^bridge=br-client" "$HOSTAPD" > /dev/null || break # handle case of private wifi
 		# shellcheck disable=SC2086 # ONLINE_SSIDs has multiple lines
 		ONLINE_SSID="$(echo $ONLINE_SSIDs | awk -F '~' -v l=$((LOOP*2)) '{print $l}')"
 		LOOP=$((LOOP+1))


### PR DESCRIPTION
This silences output, otherwise, micron.d logs `bridge=br-client` on each run