### PR TITLE
all: replace hardcoded package names with $(PKG_NAME)

### DIFF
--- a/ffda-gluon-unbound/Makefile
+++ b/ffda-gluon-unbound/Makefile
@@ -9,13 +9,13 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-gluon-unbound
+define Package/$(PKG_NAME)
   TITLE:=Drop-in replacement for the local node resolver
   DEPENDS:=+gluon-core +unbound-daemon +ca-bundle
 endef
 
-define Package/ffda-gluon-unbound/description
+define Package/$(PKG_NAME)/description
   Drop-in replacement for the local node resolver
 endef
 
-$(eval $(call BuildPackageGluon,ffda-gluon-unbound))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-gluon-usteer/Makefile
+++ b/ffda-gluon-usteer/Makefile
@@ -9,13 +9,13 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-gluon-usteer
+define Package/$(PKG_NAME)
   TITLE:=Gluon integration for the usteer daemon
   DEPENDS:=+gluon-core +usteer
 endef
 
-define Package/ffda-gluon-usteer/description
+define Package/$(PKG_NAME)/description
   Gluon integration for the usteer daemon.
 endef
 
-$(eval $(call BuildPackageGluon,ffda-gluon-usteer))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-mesh-vpn-fastd-sqm/Makefile
+++ b/ffda-mesh-vpn-fastd-sqm/Makefile
@@ -9,13 +9,13 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-mesh-vpn-fastd-sqm
+define Package/$(PKG_NAME)
   TITLE:=Enable SQM instead of simple-tc on fastd mesh vpn interface
   DEPENDS:=+gluon-mesh-vpn-fastd +sqm-scripts
 endef
 
-define Package/ffda-mesh-vpn-fastd-sqm/description
+define Package/$(PKG_NAME)/description
   Enable SQM instead of simple-tc on fastd mesh vpn interface
 endef
 
-$(eval $(call BuildPackageGluon,ffda-mesh-vpn-fastd-sqm))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-network-setup-mode/Makefile
+++ b/ffda-network-setup-mode/Makefile
@@ -9,16 +9,16 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-network-setup-mode
+define Package/$(PKG_NAME)
   TITLE:=Activate setup-mode using a magic packet
   DEPENDS:=+gluon-core
 endef
 
-define Package/ffda-network-setup-mode/install
+define Package/$(PKG_NAME)/install
 	$(Gluon/Build/Install)
 
 	$(INSTALL_DIR) $(1)/lib/gluon/setup-mode
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wait-network-request $(1)/lib/gluon/setup-mode
 endef
 
-$(eval $(call BuildPackageGluon,ffda-network-setup-mode))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-node-whisperer/Makefile
+++ b/ffda-node-whisperer/Makefile
@@ -20,20 +20,20 @@ MAKE_VARS += \
 
 Build/Compile=$(call Build/Compile/Default)
 
-define Package/ffda-node-whisperer
+define Package/$(PKG_NAME)
   TITLE:=Package to provide diagnostic information using WiFi beacons
   DEPENDS:=+gluon-core +libubox +libubus +libblobmsg-json +libnl-tiny +libbatadv +libgluonutil
 endef
 
-define Package/ffda-node-whisperer/description
+define Package/$(PKG_NAME)/description
   Package to provide diagnostic information using WiFi beacons
 endef
 
-define Package/ffda-node-whisperer/conffiles
+define Package/$(PKG_NAME)/conffiles
 /etc/config/node-whisperer
 endef
 
-define Package/ffda-node-whisperer/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc/init.d $(1)/etc/config $(1)/lib/gluon/upgrade
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/node-whisperer $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/node-whisperer/files/node-whisperer.init $(1)/etc/init.d/node-whisperer
@@ -41,4 +41,4 @@ define Package/ffda-node-whisperer/install
 	$(INSTALL_BIN) ./files/node-whisperer.upgrade.lua $(1)/lib/gluon/upgrade/150-node-whisperer
 endef
 
-$(eval $(call BuildPackageGluon,ffda-node-whisperer))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-purge-contact-info/Makefile
+++ b/ffda-purge-contact-info/Makefile
@@ -9,13 +9,13 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-purge-contact-info
+define Package/$(PKG_NAME)
   TITLE:=Purge contact-info on a Gluon node
   DEPENDS:=+gluon-core
 endef
 
-define Package/ffda-purge-contact-info/description
+define Package/$(PKG_NAME)/description
   Simple package to remove user-entered contact information.
 endef
 
-$(eval $(call BuildPackageGluon,ffda-purge-contact-info))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-ssh-manager/Makefile
+++ b/ffda-ssh-manager/Makefile
@@ -9,13 +9,13 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-ssh-manager
+define Package/$(PKG_NAME)
   TITLE:=Package to provide group-based SSH key management
   DEPENDS:=+gluon-core
 endef
 
-define Package/ffda-ssh-manager/description
+define Package/$(PKG_NAME)/description
   Package to provide group-based SSH key management
 endef
 
-$(eval $(call BuildPackageGluon,ffda-ssh-manager))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffda-usb-wan-hotplug/Makefile
+++ b/ffda-usb-wan-hotplug/Makefile
@@ -9,13 +9,13 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffda-usb-wan-hotplug
+define Package/$(PKG_NAME)
   TITLE:=Automatically adds USB ethernet devices to the WAN bridge
   DEPENDS:=+gluon-core +luaposix +libubus-lua +kmod-usb-net-rndis +kmod-usb-net-ipheth +usbmuxd
 endef
 
-define Package/ffda-usb-wan-hotplug/description
+define Package/$(PKG_NAME)/description
   Automatically adds USB ethernet devices to the WAN bridge.
 endef
 
-$(eval $(call BuildPackageGluon,ffda-usb-wan-hotplug))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-blink/Makefile
+++ b/ffgraz-blink/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-blink
+define Package/$(PKG_NAME)
   TITLE:=Adds the gluon-blink command to make your current device blink
   DEPENDS:=+gluon-core
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-blink))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-config-mode-at-runtime/Makefile
+++ b/ffgraz-config-mode-at-runtime/Makefile
@@ -8,18 +8,18 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-config-mode-at-runtime
+define Package/$(PKG_NAME)
 	SECTION:=admin
 	CATEGORY:=Administration
-	TITLE:=ffgraz-config-mode-at-runtime
+	TITLE:=$(PKG_NAME)
 	DEPENDS:= +ffgraz-web-model
 endef
 
-define Package/ffgraz-config-mode-at-runtime/description
+define Package/$(PKG_NAME)/description
 	Enable config mode server on port 81 during runtime
 endef
 
-define Package/ffgraz-config-mode-at-runtime/install
+define Package/$(PKG_NAME)/install
 	$(Gluon/Build/Install)
 
 	$(INSTALL_DIR) $(1)/lib/gluon/config-mode-runtime/view/ $(1)/lib/gluon/config-mode-runtime/www/static/
@@ -34,4 +34,4 @@ define Package/ffgraz-config-mode-at-runtime/install
 	$(LN) /lib/gluon/config-mode/www/static/gluon.css $(1)/lib/gluon/config-mode-runtime/www/static/
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-config-mode-at-runtime))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-config-mode-theme-funkfeuer/Makefile
+++ b/ffgraz-config-mode-theme-funkfeuer/Makefile
@@ -11,10 +11,10 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-config-mode-theme-funkfeuer
+define Package/$(PKG_NAME)
 	TITLE:=Gluon config mode theme for gluon-web customized for funkfeuer
 	DEPENDS:=+gluon-core +gluon-web
 	PROVIDES:=gluon-config-mode-theme
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-config-mode-theme-funkfeuer))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-ddhcpd-batman-adv/Makefile
+++ b/ffgraz-ddhcpd-batman-adv/Makefile
@@ -9,20 +9,20 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-ddhcpd-batman-adv
+define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	DEPENDS:=+micrond +ffgraz-ddhcpd
 	TITLE:=ddhcpd batman-adv integration
 endef
 
-define Package/ffgraz-ddhcpd-batman-adv/description
+define Package/$(PKG_NAME)/description
   batman-adv integration for ddhcpd
 endef
 
-define Package/ffgraz-ddhcpd-batman-adv/install
+define Package/$(PKG_NAME)/install
 	$(call Gluon/Build/Install,$(1))
 	$(CP) ./files/* $(1)/
 endef
 
-$(eval $(call BuildPackage,ffgraz-ddhcpd-batman-adv))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/ffgraz-ddhcpd-nextnode/Makefile
+++ b/ffgraz-ddhcpd-nextnode/Makefile
@@ -8,16 +8,16 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-ddhcpd-nextnode
+define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	DEPENDS:=+ffgraz-ddhcpd
 	TITLE:=ddhcpd nextnode integration
 endef
 
-define Package/ffgraz-ddhcpd-nextnode/description
+define Package/$(PKG_NAME)/description
   nextnode integration for ddhcpd
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-ddhcpd-nextnode))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))
 

--- a/ffgraz-ddhcpd/Makefile
+++ b/ffgraz-ddhcpd/Makefile
@@ -19,14 +19,14 @@ TARGET_CFLAGS += -DLOG_LEVEL_LIMIT=5
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-ddhcpd
+define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	DEPENDS:=+libnl-tiny
 	TITLE:=ddhcpd
 endef
 
-define Package/ffgraz-ddhcpd/description
+define Package/$(PKG_NAME)/description
 	distributed dhcp server
 endef
 
@@ -35,11 +35,11 @@ define Build/Compile
 	CFLAGS="$(TARGET_CFLAGS)" LIBNL_NAME=libnl-tiny BUILD_DIR="$(BUILD_DIR)" $(MAKE) -C $(PKG_BUILD_DIR) $(TARGET_CONFIGURE_OPTS)
 endef
 
-define Package/ffgraz-ddhcpd/install
+define Package/$(PKG_NAME)/install
 	$(call Gluon/Build/Install,$(1))
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ddhcpd  $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ddhcpdctl $(1)/usr/sbin/
 endef
 
-$(eval $(call BuildPackage,ffgraz-ddhcpd))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/ffgraz-mesh-olsr12-openvpn/Makefile
+++ b/ffgraz-mesh-olsr12-openvpn/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-mesh-olsr12-openvpn
+define Package/$(PKG_NAME)
   TITLE:=olsrd v1 to v2 migration fallback vpn
   DEPENDS:= +gluon-mesh-olsrd +openvpn
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-mesh-olsr12-openvpn))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-mesh-vpn-openvpn/Makefile
+++ b/ffgraz-mesh-vpn-openvpn/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-mesh-vpn-openvpn
+define Package/$(PKG_NAME)
   TITLE:=Support for connecting meshes via custom openvpn configuration
   DEPENDS:=+gluon-core +gluon-mesh-vpn-core +openvpn +lua-openssl
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-mesh-vpn-openvpn))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-olsr-auto-restart/Makefile
+++ b/ffgraz-olsr-auto-restart/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-olsr-auto-restart
+define Package/$(PKG_NAME)
   TITLE:=Automatically restart olsr
   DEPENDS:= +gluon-mesh-olsrd +micrond
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-olsr-auto-restart))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-private-ap/Makefile
+++ b/ffgraz-private-ap/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-private-ap
+define Package/$(PKG_NAME)
   TITLE:=Provides a virtual access point for the nodes client network
   DEPENDS:=+gluon-core
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-private-ap))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-static-ip/Makefile
+++ b/ffgraz-static-ip/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-static-ip
+define Package/$(PKG_NAME)
   TITLE:=Static IP assignment and configuration for gluon
   DEPENDS:=+gluon-core +luci-lib-ip
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-static-ip))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-web-mesh-vpn-openvpn/Makefile
+++ b/ffgraz-web-mesh-vpn-openvpn/Makefile
@@ -7,9 +7,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-web-mesh-vpn-openvpn
+define Package/$(PKG_NAME)
   TITLE:=gluon-web module to upload keys for openvpn mesh-vpn
   DEPENDS:=+gluon-web-admin +ffgraz-web-model +ffgraz-mesh-vpn-openvpn +lua-openssl
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-web-mesh-vpn-openvpn))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-web-model/Makefile
+++ b/ffgraz-web-model/Makefile
@@ -7,9 +7,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-web-model
+define Package/$(PKG_NAME)
   TITLE:=Module that adds custom web-model elements to gluon-web-model
   DEPENDS:=+gluon-web-model
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-web-model))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-web-private-ap/Makefile
+++ b/ffgraz-web-private-ap/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-web-private-ap
+define Package/$(PKG_NAME)
   DEPENDS:=+gluon-web-admin +ffgraz-private-ap
   TITLE:=UI for activating a private AP
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-web-private-ap))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-web-static-ip/Makefile
+++ b/ffgraz-web-static-ip/Makefile
@@ -4,9 +4,9 @@ PKG_NAME:=ffgraz-web-static-ip
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-web-static-ip
+define Package/$(PKG_NAME)
   DEPENDS:=+gluon-web-admin +ffgraz-web-model +ffgraz-static-ip
   TITLE:=UI for managing static IPs
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-web-static-ip))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffgraz-yggdrasil/Makefile
+++ b/ffgraz-yggdrasil/Makefile
@@ -7,9 +7,9 @@ PKG_LICENSE:=MIT
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffgraz-yggdrasil
+define Package/$(PKG_NAME)
   TITLE:=yggdrasil integration
   DEPENDS:=+gluon-core +yggdrasil
 endef
 
-$(eval $(call BuildPackageGluon,ffgraz-yggdrasil))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffka-gluon-web-usb-wan-hotplug/Makefile
+++ b/ffka-gluon-web-usb-wan-hotplug/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffka-gluon-web-usb-wan-hotplug
+define Package/$(PKG_NAME)
   TITLE:=gluon-web module to enable and disable ffda-usb-wan-hotplug
   DEPENDS:=+gluon-web-admin +ffda-usb-wan-hotplug
 endef
 
-$(eval $(call BuildPackageGluon,ffka-gluon-web-usb-wan-hotplug))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffmuc-mesh-vpn-wireguard-vxlan/Makefile
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/Makefile
@@ -9,9 +9,9 @@ PKG_LICENSE:=GPL-2.0-or-later
 
 include $(TOPDIR)/../package/gluon.mk
 
-define Package/ffmuc-mesh-vpn-wireguard-vxlan
+define Package/$(PKG_NAME)
   TITLE:=Support for connecting meshes via wireguard
   DEPENDS:=+gluon-mesh-vpn-core +micrond +kmod-wireguard +wireguard-tools +ip-full +lua-jsonc
 endef
 
-$(eval $(call BuildPackageGluon,ffmuc-mesh-vpn-wireguard-vxlan))
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))


### PR DESCRIPTION
It is best practice to not repeat the PKG_NAME multiple times, as it reduces the changes when renaming a package.

This unifies the way packages are defined, by using the PKG_NAME variable when possible in the Makefile.

I don't know any downside to this, so I hope that everybody is fine with this change in their maintained package?

I would like to get feedback from some other people active in this repository, before merging this.