### PR TITLE
ffda-node-whisperer: update url to NodeMonitor

### DIFF
--- a/ffda-node-whisperer/README.md
+++ b/ffda-node-whisperer/README.md
@@ -3,4 +3,4 @@
 This program encodes information about the status of a Gluon Node
 into the beacons of the wireless client networks.
 This information can be decoded and sent to a community using
-a companion app called [NodeMonitor](https://github.com/blocktrron/NodeMonitor).
+a companion app called [NodeMonitor](https://github.com/freifunk-darmstadt/NodeMonitor).


### PR DESCRIPTION
I guess the url to the NodeMonitor repository should be updated.

@blocktrron could you please verify if the new url is correct?