### PR TITLE
ffda-usb-wan-hotplug: remove old mesh_wan check

### DIFF
--- a/ffda-usb-wan-hotplug/files/etc/hotplug.d/usb/10-usb-wan-hotplug
+++ b/ffda-usb-wan-hotplug/files/etc/hotplug.d/usb/10-usb-wan-hotplug
@@ -2,11 +2,9 @@ NETPATH="/sys${DEVPATH}/net"
 LOCKPATH="/tmp/usb-wan-hotplug-devpath"
 
 ENABLED=$(uci get usb-wan-hotplug.settings.enabled)
-MESH_WAN=$(uci get network.mesh_wan.disabled)
 
 if [ "${ACTION}" = "add" ]; then
 	[ "${ENABLED}" != "1" ] && exit 0
-	[ "${MESH_WAN}" != "1" ] && exit 0
 	test -e "${LOCKPATH}" && exit 0
 	if test -e  "${NETPATH}"; then
 		logger -t hotplug "Network USB device was plugged in"


### PR DESCRIPTION
it should be up to the user to disable this if mesh on wan is enabled. I think it should not be harmful to have this enabled, while it of course is not very useful to have Mesh-on-WAN enabled when using the usb-wan-hotplug functionality

Currently, this package does not work with gluon version which switched to the role API
https://gluon.readthedocs.io/en/v2021.1.1/features/roles.html

closes #126 