### PR TITLE
ffac-mt7915-hotfix: initial package version

### DIFF
--- a/ffac-mt7915-hotfix/LICENSE
+++ b/ffac-mt7915-hotfix/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Felix Baumann, Florian Maurer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ffac-mt7915-hotfix/Makefile
+++ b/ffac-mt7915-hotfix/Makefile
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2024 Felix Baumann, Florian Maurer (FFAC)
+# SPDX-License-Identifier: MIT
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-mt7915-hotfix
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=reboot device if mt7915e driver shows known failure symptom
+  DEPENDS:=@(TARGET_mediatek_filogic||TARGET_ramips_mt7621||TARGET_mediatek_mt7622) kmod-mt7915e +gluon-core +micrond
+  MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-mt7915-hotfix/README.md
+++ b/ffac-mt7915-hotfix/README.md
@@ -1,0 +1,36 @@
+ffac-mt7915-hotfix
+=============
+
+This package reboots the device if the mt7915-firmware hangs on ramips-mt7621
+and mediatek-filogic. It's meant as a hotfix for the mcu timeout issue:
+https://github.com/freifunk-gluon/gluon/issues/3154
+The issue popped up with Gluon v2023.2, earlier releases are not affected.
+
+Credits go to istrator from FFMUC who found the rf_regval correlation.
+
+Create a file `modules` with the following content in your `./gluon/site/`
+directory and add these lines: 
+
+```
+GLUON_SITE_FEEDS="community"
+PACKAGES_COMMUNITY_REPO=https://github.com/freifunk-gluon/community-packages.git
+PACKAGES_COMMUNITY_COMMIT=*/missing/*
+PACKAGES_COMMUNITY_BRANCH=master
+```
+
+Now you can add the package `ffac-mt7915-hotfix` to your site.mk
+(`*/missing/*` has to be replaced by the github-commit-ID of the version you
+want to use, you have to pick it manually.)
+
+Further info on the issue this tries to prevent from happening:
+I've seen the MCU timeout issue happening as early as 16 hours of uptime.
+MCU timeouts result in WiFi not working. WiFi mesh nodes running into the
+issue go offline until they are rebooted manually while any wired node is
+still accessible via ssh.
+
+On most devices it will take days or weeks for this issue to manifest,
+while others are affected daily. This is due to the difference in clients
+that are connecting to it on a frequent base. The more people frequent
+the device the more probable it is to go offline.
+
+Also see https://github.com/freifunk-gluon/gluon/issues/3154

--- a/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
+++ b/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+if ls /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null && ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
+    logger -s -t "ffac-mt7915-hotfix" -p err "wifi firmware crashed, scheduled reboot in 5 seconds"
+    sleep 5
+    # Autoupdate?
+    upgrade_started='/tmp/autoupdate.lock'
+    if [ -f $upgrade_started ] ; then
+        logger -s -t "ffac-mt7915-hotfix" -p 5 "Autoupdate running! Aborting"
+        exit 2
+    fi
+    reboot
+fi

--- a/ffac-mt7915-hotfix/files/usr/lib/micron.d/mt7915-hotfix
+++ b/ffac-mt7915-hotfix/files/usr/lib/micron.d/mt7915-hotfix
@@ -1,0 +1,2 @@
+# run every second minute
+*/2 * * * * /lib/gluon/mt7915/reboot-on-error.sh


### PR DESCRIPTION
This package reboots the device if the mt7915-firmware hangs on ramips-mt7621 and mediatek-filogic.

It's meant as a hotfix for the mcu timeout issue: https://github.com/freifunk-gluon/gluon/issues/3154

which occurs on all devices with an mt7915 wifi driver