### PR TITLE
ffac-mt7915e-hotfix: silence stderr from ls command in cron

### DIFF
--- a/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
+++ b/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if ls /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null && ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
+if ls /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval 2>&1 > /dev/null && ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
     logger -s -t "ffac-mt7915-hotfix" -p err "wifi firmware crashed, scheduled reboot in 5 seconds"
     sleep 5
     # Autoupdate?

--- a/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
+++ b/ffac-mt7915-hotfix/files/lib/gluon/mt7915/reboot-on-error.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if ls /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval 2>&1 > /dev/null && ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
+if ls /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null 2>&1 && ! cat /sys/kernel/debug/ieee80211/phy*/mt76/rf_regval > /dev/null; then
     logger -s -t "ffac-mt7915-hotfix" -p err "wifi firmware crashed, scheduled reboot in 5 seconds"
     sleep 5
     # Autoupdate?


### PR DESCRIPTION
This occurs on devices without an mt76 phy