### PR TITLE
ffac-autoupdater-wifi-fallback: remove requirement of wpa-supplicant

### DIFF
--- a/ffac-autoupdater-wifi-fallback/LICENSE
+++ b/ffac-autoupdater-wifi-fallback/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2023 kb-light, Patric Steffen, Andreas Ziegler, Florian Maurer
+Copyright (c) 2024 kb-light, Patric Steffen, Andreas Ziegler, Florian Maurer, Maximilian Baumgartner
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/ffac-autoupdater-wifi-fallback/Makefile
+++ b/ffac-autoupdater-wifi-fallback/Makefile
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2023 kb-light, Patric Steffen, Andreas Ziegler, Florian Maurer
+# SPDX-FileCopyrightText: 2024 kb-light, Patric Steffen, Andreas Ziegler, Florian Maurer, Maximilian Baumgartner
 # SPDX-License-Identifier: BSD-2-Clause
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffac-autoupdater-wifi-fallback
-PKG_VERSION:=2
+PKG_VERSION:=3
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
@@ -13,7 +13,7 @@ include $(TOPDIR)/../package/gluon.mk
 
 define Package/$(PKG_NAME)
   TITLE:=Implements switching to fallback mode if we are cut off from the mesh
-  DEPENDS:=+gluon-autoupdater +gluon-site +gluon-state-check +iw +libgluonutil +libiwinfo-lua +luabitop +luaposix +micrond +wpa-supplicant-mini
+  DEPENDS:=+gluon-autoupdater +gluon-site +gluon-state-check +iw +libgluonutil +libiwinfo-lua +libubus-lua +luabitop +luaposix +micrond
   MAINTAINER:=Freifunk Aachen <kontakt@freifunk-aachen.de>
 endef
 

--- a/ffac-autoupdater-wifi-fallback/luasrc/lib/gluon/upgrade/510-autoupdater-wifi-fallback
+++ b/ffac-autoupdater-wifi-fallback/luasrc/lib/gluon/upgrade/510-autoupdater-wifi-fallback
@@ -14,7 +14,6 @@ uci:section('autoupdater-wifi-fallback', 'autoupdater-wifi-fallback', 'settings'
   enabled = enabled,
 })
 
-uci:delete('wireless', 'fallback')
 uci:delete('network', 'fallback')
 uci:delete('network', 'fallback6')
 
@@ -32,7 +31,6 @@ uci:section('network', 'interface', 'fallback6',{
 
 uci:save('autoupdater-wifi-fallback')
 uci:save('network')
-uci:save('wireless')
 
 local file = io.open('/usr/lib/micron.d/autoupdater', 'r')
 local content = file:read "*a"

--- a/ffac-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
+++ b/ffac-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
@@ -5,6 +5,8 @@ local util = require 'gluon.util'
 local bit = require 'bit'
 local fcntl = require 'posix.fcntl'
 local unistd = require 'posix.unistd'
+local ubus = require('ubus').connect()
+local wireless = require 'gluon.wireless'
 
 local configname = 'autoupdater-wifi-fallback'
 local lockfilename = '/var/lock/' .. configname .. '.lock'
@@ -95,30 +97,22 @@ end
 
 local function switch_to_fallback_mode(radio, ssid, bssid)
   autil.log('out', 'connecting to '  .. radio .. ' ' .. ssid .. ' ' .. bssid)
-  uci:delete_all('wireless', 'wifi-iface')
-  uci:section('wireless', 'wifi-iface', 'fallback', {
-    device = radio,
-    network = 'fallback',
-    mode = 'sta',
-    disabled = false,
-    macaddr = util.generate_mac(3, 10),
-    bssid = bssid,
-    ssid = ssid,
-    ifname = 'fallback',
-    encryption = 'none',
-  })
-  uci:set('wireless', radio, 'disabled', false)
-  uci:save('wireless')
-
-  os.execute('wifi')
-  os.execute('sleep 5')
-  uci:revert('wireless')
+  os.execute('sleep 2')
+  ubus:call('network', 'add_dynamic', {name = "fallback", ifname = "fallback", proto = "dhcp", device = "fallback", l3_device = "fallback"})
+  ubus:call('network', 'add_dynamic', {name = "fallback6", ifname = "fallback", proto = "dhcpv6", device = "fallback", l3_device = "fallback"})
+  ubus:call('network.interface.fallback', 'add_device', {name = "fallback"})
+  ubus:call('network.interface.fallback6', 'add_device', {name = "fallback"})
+  ubus:call('network.interface.fallback', 'up', {})
+  ubus:call('network.interface.fallback6', 'up', {})
+  os.execute('sleep 2')
+  os.execute('iw dev fallback connect ' .. ssid .. ' ' .. bssid)
   os.execute('sleep 20')
 end
 
 local function revert_to_standard_mode()
   autil.log('out', 'going back to standard mode')
-  os.execute('/etc/init.d/network restart')
+  os.execute('/etc/init.d/wpad start')
+  os.execute('wifi up')
   os.execute('sleep 30')
 end
 
@@ -142,15 +136,28 @@ if (force or preflight_check()) and not connectivity_check() then
 
   if force or tonumber(unreachable_since) + offset < os.time() then
     autil.log('out', 'going to fallback mode')
+    os.execute('wifi down')
+    os.execute('/etc/init.d/wpad status >/dev/null && /etc/init.d/wpad stop')
     for radio, netlist in pairs(autil.get_available_wifi_networks()) do
+      local radio_config = uci:get_all('wireless', radio)
+      local phy = wireless.find_phy(radio_config)
+      autil.log('out', 'using ' .. phy .. ' to create fallback interface')
+      os.execute('iw phy ' .. phy .. ' interface add fallback type managed')
+      os.execute('ip link set dev fallback up')
       for _, net in ipairs(netlist) do
         switch_to_fallback_mode(radio, net.ssid, net.bssid)
         if run_autoupdater() == 0 then
           break
         end
+        ubus:call('network.interface.fallback', 'down', {})
+        ubus:call('network.interface.fallback', 'remove', {})
+        ubus:call('network.interface.fallback6', 'down', {})
+        ubus:call('network.interface.fallback6', 'remove', {})
+        os.execute('iw dev fallback disconnect')
       end
+      os.execute('iw dev fallback del')
     end
-    -- this is only reached if no updated happened
+    -- this is only reached if no update happened
     revert_to_standard_mode()
   end
 else

--- a/ffac-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
+++ b/ffac-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
@@ -98,14 +98,12 @@ end
 local function switch_to_fallback_mode(radio, ssid, bssid)
   autil.log('out', 'connecting to '  .. radio .. ' ' .. ssid .. ' ' .. bssid)
   os.execute('sleep 2')
-  ubus:call('network', 'add_dynamic', {name = "fallback", ifname = "fallback", proto = "dhcp", device = "fallback", l3_device = "fallback"})
-  ubus:call('network', 'add_dynamic', {name = "fallback6", ifname = "fallback", proto = "dhcpv6", device = "fallback", l3_device = "fallback"})
-  ubus:call('network.interface.fallback', 'add_device', {name = "fallback"})
-  ubus:call('network.interface.fallback6', 'add_device', {name = "fallback"})
-  ubus:call('network.interface.fallback', 'up', {})
-  ubus:call('network.interface.fallback6', 'up', {})
+  ubus:call('network', 'add_dynamic', {name = "fallback", proto = "dhcp"})
+  ubus:call('network', 'add_dynamic', {name = "fallback6", proto = "dhcpv6"})
+  ubus:call('network.interface.fallback', 'add_device', {name = "fallback_if"})
+  ubus:call('network.interface.fallback6', 'add_device', {name = "fallback_if"})
   os.execute('sleep 2')
-  os.execute('iw dev fallback connect ' .. ssid .. ' ' .. bssid)
+  os.execute('iw dev fallback_if connect ' .. ssid .. ' ' .. bssid)
   os.execute('sleep 20')
 end
 
@@ -141,9 +139,9 @@ if (force or preflight_check()) and not connectivity_check() then
     for radio, netlist in pairs(autil.get_available_wifi_networks()) do
       local radio_config = uci:get_all('wireless', radio)
       local phy = wireless.find_phy(radio_config)
-      autil.log('out', 'using ' .. phy .. ' to create fallback interface')
-      os.execute('iw phy ' .. phy .. ' interface add fallback type managed')
-      os.execute('ip link set dev fallback up')
+      autil.log('out', 'using ' .. phy .. ' to create fallback_if interface')
+      os.execute('iw phy ' .. phy .. ' interface add fallback_if type managed')
+      os.execute('ip link set dev fallback_if up')
       for _, net in ipairs(netlist) do
         switch_to_fallback_mode(radio, net.ssid, net.bssid)
         if run_autoupdater() == 0 then
@@ -153,9 +151,9 @@ if (force or preflight_check()) and not connectivity_check() then
         ubus:call('network.interface.fallback', 'remove', {})
         ubus:call('network.interface.fallback6', 'down', {})
         ubus:call('network.interface.fallback6', 'remove', {})
-        os.execute('iw dev fallback disconnect')
+        os.execute('iw dev fallback_if disconnect')
       end
-      os.execute('iw dev fallback del')
+      os.execute('iw dev fallback_if del')
     end
     -- this is only reached if no update happened
     revert_to_standard_mode()


### PR DESCRIPTION
This finally fixes the additional wpa-supplicant-mini requirement for the ffac-autoupdater-wifi-fallback (see issue https://github.com/freifunk-gluon/community-packages/pull/33#issuecomment-1876069806 for more information).

As the functionality is quite handy to have it on all devices, it should not be bloated.
The package does now works again with gluon releases v2022.x and v2023.x (and should still work on older releases) without additional wpasupplicant packages.

It uses `ubus call add_dynamic`  to add a network at runtime and then attach it to a network device.
