### PR TITLE
Add ffbs-parker-nextnode

### DIFF
--- a/ffbs-parker-nextnode/Makefile
+++ b/ffbs-parker-nextnode/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffbs-parker-nextnode
+PKG_VERSION:=1
+
+PKG_MAINTAINER:=Chris Fiege <chris@tinyhost.de>
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ffbs-parker-nextnode
+  TITLE:=gluon-nextnode config for parker
+  DEPENDS:=+ffbs-parker-nodeconfig
+endef
+
+define Package/ffbs-parker-nextnode/description
+	This package adds ebtables rules for the parker nextnode range.
+	This package is needed when the nextnode-ips are outside of the
+	local net of the router - what is usually the case for parker networks.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/ffbs-parker-nextnode/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,ffbs-parker-nextnode))
+

--- a/ffbs-parker-nextnode/Makefile
+++ b/ffbs-parker-nextnode/Makefile
@@ -6,9 +6,7 @@ PKG_VERSION:=1
 PKG_MAINTAINER:=Chris Fiege <chris@tinyhost.de>
 PKG_LICENSE:=MIT
 
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/../package/gluon.mk
 
 define Package/ffbs-parker-nextnode
   TITLE:=gluon-nextnode config for parker
@@ -20,19 +18,5 @@ define Package/ffbs-parker-nextnode/description
 	local net of the router - what is usually the case for parker networks.
 endef
 
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-endef
-
-define Build/Configure
-endef
-
-define Build/Compile
-endef
-
-define Package/ffbs-parker-nextnode/install
-	$(CP) ./files/* $(1)/
-endef
-
-$(eval $(call BuildPackage,ffbs-parker-nextnode))
+$(eval $(call BuildPackageGluon,ffbs-parker-nextnode))
 

--- a/ffbs-parker-nextnode/Makefile
+++ b/ffbs-parker-nextnode/Makefile
@@ -12,7 +12,6 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/ffbs-parker-nextnode
   TITLE:=gluon-nextnode config for parker
-  DEPENDS:=+ffbs-parker-nodeconfig
 endef
 
 define Package/ffbs-parker-nextnode/description

--- a/ffbs-parker-nextnode/README.md
+++ b/ffbs-parker-nextnode/README.md
@@ -1,0 +1,38 @@
+ffbs-parker-nextnode
+====================
+
+This is a package of [gluon-parker](https://github.com/ffbs/gluon-parker),
+a Gluon fork that uses routing between the nodes
+(aka. Router devices) and the infrastructure.
+It is currently in use at Freifunk Braunschweig.
+Other communities are interested in adopting it as well.
+
+This package provides `ebtables`-rules that redirect traffic to the
+`localnode` IPs on the node itself.
+
+This is needed in networks where the `localnode` addresses are outside the client network - for example when 
+using with `parker`.
+
+In Freifunk Braunschweig, for example, the `localnode` address is `2001:bf7:382:0::1`.
+But the IP addresses of routers and clients are in `2001:bf7:381::`.
+With this rule traffic to the `localnode` address is always forwarded to the router.
+
+(The service on the router should redirect the client to one of routers public addresses - otherwise the TCP connection
+would break when the client roams to another node with the same redirect.)
+
+site.conf
+---------
+
+Your `site.conf` probably already contains a `next_node` section, as
+requested by the [documentation](https://gluon.readthedocs.io/en/latest/user/site.html).
+
+For Freifunk Braunschweig this section look like this:
+
+```json
+next_node = {
+        ip4 = "172.16.127.1",
+        ip6 = "2001:bf7:382:0::1",
+        name = { "node.ffbs" },
+        mac = "72:02:46:6a:1c:27",
+},
+```

--- a/ffbs-parker-nextnode/files/lib/gluon/ebtables/399-localnode
+++ b/ffbs-parker-nextnode/files/lib/gluon/ebtables/399-localnode
@@ -1,0 +1,12 @@
+local client_bridge = require 'gluon.client_bridge'
+local site = require 'gluon.site'
+local next_node = site.next_node({})
+local macaddr = client_bridge.next_node_macaddr()
+
+if next_node.ip4 then
+        rule('PREROUTING -p IPv4 -d ! ' .. macaddr .. ' --ip-dst ' .. site.next_node.ip4() .. ' -j dnat --to-dst ' .. macaddr .. ' --dnat-target ACCEPT', 'nat')
+end
+
+if next_node.ip6 then
+	rule('PREROUTING -p IPv6 -d ! ' .. macaddr .. ' --ip6-dst ' .. site.next_node.ip6() .. ' -j dnat --to-dst ' .. macaddr .. ' --dnat-target ACCEPT', 'nat')
+end


### PR DESCRIPTION
Thia adds ffbs-parker-nextnode - a package of the *parker*-flavor of Gluon.

This package provides `ebtables`-rules that redirect traffic to the
`localnode` IPs on the node itself.

This is needed in networks where the `localnode` addresses are outside the client network - for example when 
using with `parker`.

In Freifunk Braunschweig, for example, the `localnode` address is `2001:bf7:382:0::1`.
But the IP addresses of routers and clients are in `2001:bf7:381::`.
With this rule traffic to the `localnode` address is always forwarded to the router.

(The service on the router should redirect the client to one of routers public addresses - otherwise the TCP connection
would break when the client roams to another node with the same redirect.)

Previously this package has been managed in
https://gitli.stratum0.org/ffbs/ffbs-packages under the name `gluon-ffbsnext-nextnode`.
Last commit-id: 2241cee3e4be96ded955f6bfd40a42cd9b7e53ac