### PR TITLE
wireguard-registration: on openwrt24.10 the https check prints to stderr

### DIFF
--- a/ffac-wg-registration/files/lib/gluon/wg-registration/registration.sh
+++ b/ffac-wg-registration/files/lib/gluon/wg-registration/registration.sh
@@ -4,7 +4,9 @@ if [ "$(uci get gluon.mesh_vpn.enabled)" = "true" ] || [ "$(uci get gluon.mesh_v
 	# check if registration has been done since last boot
 	if [ ! -f /tmp/WG_REGISTRATION_SUCCESSFUL ]; then
 		# Push public key to broker, test for https and use if supported
-		wget -q "https://[::1]"
+		wget -q "https://[::1]" 2>/dev/null
+		# returns Network Failure =4 if https exists
+		# and Generic Error =1 if no ssl lib available
 		if [ $? -eq 1 ]; then
 			PROTO=http
 		else

--- a/ffmuc-mesh-vpn-wireguard-vxlan/shsrc/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/shsrc/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -258,7 +258,7 @@ SEGMENT=$(uci get gluon.core.domain)
 
 # Push public key to broker and receive gateway data, test for https and use if supported
 ret=0
-wget -q "https://[::1]" || ret=$?
+wget -q "https://[::1]" 2>/dev/null || ret=$?
 # returns Network Failure =4 if https exists
 # and Generic Error =1 if no ssl lib available
 if [ "$ret" -eq 1 ]; then


### PR DESCRIPTION
We therefore pipe the output to /dev/null so that the below error message does not appear in `logread` output.

The Error message is:
`SSL error: NET - Sending information through the socket failed`

The returncode behavior stays the same otherwise.