### PR TITLE
ffac-ssid-changer: silence grep if going offline

### DIFF
--- a/ffac-ssid-changer/shsrc/ssid-changer.sh
+++ b/ffac-ssid-changer/shsrc/ssid-changer.sh
@@ -181,7 +181,7 @@ elif [ "$CHECK" -eq 0 ]; then
 			LOOP=1
 			for HOSTAPD in /var/run/hostapd-*.conf; do
 				[ -e "$HOSTAPD" ] || break  # handle the case of no hostapd-* files
-				grep "^bridge=br-client" "$HOSTAPD" || continue # handle case of private wifi
+				grep "^bridge=br-client" "$HOSTAPD" > /dev/null || continue # handle case of private wifi
 				# shellcheck disable=SC2086 # ONLINE_SSIDs has multiple lines
 				ONLINE_SSID="$(echo $ONLINE_SSIDs | awk -F '~' -v l=$((LOOP*2)) '{print $l}')"
 				LOOP=$((LOOP+1))


### PR DESCRIPTION
This was done in #117 but the case when going offline was missing.

This is finally fixed with this PR for the "old ssid-changer", until the new one from #138 is ready