### PR TITLE
ffbs-mesh-vpn-parker: fix shell word splitting

### DIFF
--- a/ffbs-mesh-vpn-parker/files/etc/init.d/nodeconfig
+++ b/ffbs-mesh-vpn-parker/files/etc/init.d/nodeconfig
@@ -6,13 +6,12 @@
 START=99
 
 USE_PROCD=1
-PROG='/usr/bin/gluon-wan /usr/sbin/nodeconfig.sh'
 
 start_service() {
 	sleep 30
 	logger -t nodeconfig:init.d Starting Service
         procd_open_instance
-        procd_set_param command "$PROG"
+        procd_set_param command /usr/bin/gluon-wan /usr/sbin/nodeconfig.sh
         procd_set_param respawn
         procd_set_param stderr 0
         #procd_set_param limits core="unlimited"  #TODO set ulimit 


### PR DESCRIPTION
We actually want to split these arguments to procd_set_param command. Otherwise procd reports a crash loop.