### PR TITLE
ffbs-mesh-vpn-parker: Remove all wireguard interfaces on autoupdate

### DIFF
--- a/ffbs-mesh-vpn-parker/files/usr/lib/autoupdater/upgrade.d/85parker
+++ b/ffbs-mesh-vpn-parker/files/usr/lib/autoupdater/upgrade.d/85parker
@@ -3,6 +3,9 @@
 # shellcheck source=/dev/null
 . /lib/gluon/autoupdater/lib.sh
  
-ip link del dev wg_c1
-ip link del dev wg_c2
-ip link del dev wg_c3
+echo "Removing Parker Wireguard interfaces:"
+for iface in $(ip l | grep "wg_" | cut -d" " -f 2 | cut -d":" -f 0)
+do
+	echo "- Removing $iface"
+	ip link del dev "$iface"
+done


### PR DESCRIPTION
Removing all wireguard interfaces on autoupdate is important: This way we reduce the memory footprint during update.

Parker (in Braunschweig) has moved from using only three pre-defined interfaces to using multiple interfaces.
Others communities will likely do the same.

With this change we remove all `wg_*` interfaces.