### PR TITLE
ci: sync linting to the version in gluon-packages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,13 @@
+---
 name: Lint
 on:
+  workflow_dispatch:
   push:
   pull_request:
     types: [opened, synchronize, reopened]
+
 jobs:
-  Lua:
+  lua:
     name: Lua
     runs-on: ubuntu-latest
     steps:
@@ -13,3 +16,17 @@ jobs:
         run: sudo apt-get install lua-check
       - name: Lint Lua
         run: luacheck .
+
+  sh:
+    name: Shell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        # Make sure the action is pinned to a commit, as all reviewdog repos
+        # have hundreds of contributors with write access (breaks easy/often)
+        uses: reviewdog/action-shellcheck@5ebd09ddbe2ebb471646ce234c6c8dd18663ca7c  # v1.30.0
+        with:
+          fail_level: any
+          check_all_files_with_shebangs: true
+          filter_mode: nofilter

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# Better busybox ash compatibility without requiring shellcheck 0.10+
+disable=SC2039,SC3043,SC3037,SC3057


### PR DESCRIPTION
Syncs/adds the CI linting changes that were recently added to gluon-packages: https://github.com/freifunk-gluon/packages/pull/276

The consensus during the last Gluon meetup was that the gluon-community repository shouldn't have more strict linting than the main repository.