### PR TITLE
ffbs-mesh-vpn-parker: Implement traffic control

### DIFF
--- a/ffbs-mesh-vpn-parker/Makefile
+++ b/ffbs-mesh-vpn-parker/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/../package/gluon.mk
 
 define Package/ffbs-mesh-vpn-parker
   TITLE:=Automatic node configuration for parker networks
-  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +kmod-wireguard +wireguard-tools +luaposix +usign +gluon-radv-filterd +gluon-ebtables-filter-ra-dhcp +ffbs-parker-nextnode +ffbs-parker-respondd
+  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +kmod-wireguard +wireguard-tools +luaposix +usign +gluon-radv-filterd +gluon-ebtables-filter-ra-dhcp +ffbs-parker-nextnode +ffbs-parker-respondd +simple-tc
   PROVIDES:=ffbs-parker-nodeconfig
 endef
 

--- a/ffbs-mesh-vpn-parker/files/usr/sbin/noderoute.sh
+++ b/ffbs-mesh-vpn-parker/files/usr/sbin/noderoute.sh
@@ -27,7 +27,7 @@ check_batman() {
 
 while true; do
 	$LOGGER Cycling
-	if ! lua /usr/share/lua/noderoute.lua $tmpdir | $LOGGER; then
+	if ! lua /usr/share/lua/noderoute.lua $tmpdir ; then
 		$LOGGER noderoute.lua returned non-zero
 	fi
 	touch ${tmpdir}/noderoute-successful

--- a/ffbs-mesh-vpn-parker/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/parker.lua
+++ b/ffbs-mesh-vpn-parker/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/parker.lua
@@ -2,7 +2,6 @@ local uci = require("simple-uci").cursor()
 
 local site = require("gluon.site")
 local util = require("gluon.util")
-local vpn_core = require("gluon.mesh-vpn")
 
 local M = {}
 
@@ -23,20 +22,6 @@ end
 
 function M.active()
 	return site.mesh_vpn.parker() ~= nil
-end
-
-function M.set_limit(ingress_limit, egress_limit)
-	uci:delete("simple-tc", "mesh_vpn")
-	if ingress_limit ~= nil and egress_limit ~= nil then
-		uci:section("simple-tc", "interface", "mesh_vpn", {
-			ifname = vpn_core.get_interface(),
-			enabled = true,
-			limit_egress = egress_limit,
-			limit_ingress = ingress_limit,
-		})
-	end
-
-	uci:save("simple-tc")
 end
 
 function M.mtu()

--- a/ffbs-mesh-vpn-parker/luasrc/usr/share/lua/nodeconfig.lua
+++ b/ffbs-mesh-vpn-parker/luasrc/usr/share/lua/nodeconfig.lua
@@ -77,7 +77,7 @@ local function apply_wg(conf)
 							)
 							do_it = true
 						end
-						if cur_conf.keepalive ~= target.keepalive then
+						if cur_conf.keepalive ~= conf.wg_keepalive then
 							util.log(
 								"wg-iface "
 									.. iface
@@ -86,7 +86,7 @@ local function apply_wg(conf)
 									.. ". Keepalive has changed from "
 									.. cur_conf.keepalive
 									.. " to "
-									.. target.keepalive
+									.. conf.wg_keepalive
 							)
 							do_it = true
 						end

--- a/ffbs-mesh-vpn-parker/luasrc/usr/share/lua/util.lua
+++ b/ffbs-mesh-vpn-parker/luasrc/usr/share/lua/util.lua
@@ -75,7 +75,7 @@ function util.get_wg_info()
 			peer["latest_handshake"] = tonumber(line[6])
 			peer["transfer_rx"] = tonumber(line[7])
 			peer["transfer_tx"] = tonumber(line[8])
-			peer["persistent_keepalive"] = tonumber(line[8])
+			peer["persistent_keepalive"] = tonumber(line[9])
 			results[line[1]]["peers"][line[2]] = peer
 		end
 	end


### PR DESCRIPTION
Until now parker did not implement traffic shaping according to what the user defined in config mode.

With this change we implement `simple-tc` for parker. If the user now chooses to limit the bandwidth we use the standard gluon way limit the bandwidth for each tunnel individually.

We also communicate the traffic limits to the config service. This way the coordinators could also implement traffic shaping for ingress (infrastructure to router) on the infrastructure-side instead of the router in the future.

TODO:

* [x] Merge #159 first and rebase this PR on master afterwards.