### PR TITLE
ffbs-mesh-vpn-parker: Let nodeconfig report success even if vpn disabled

### DIFF
--- a/ffbs-mesh-vpn-parker/files/usr/sbin/nodeconfig.sh
+++ b/ffbs-mesh-vpn-parker/files/usr/sbin/nodeconfig.sh
@@ -56,6 +56,7 @@ fi
 while true; do
 	vpn_enabled=$(uci get gluon.mesh_vpn.enabled)
 	if [ "$vpn_enabled" == 0 ]; then
+		touch ${tmpdir}/nodeconfig-successful
 		sleep $DEFAULT_SLEEP
 		continue
 	fi


### PR DESCRIPTION
The `nodeconfig` and `noderoute` services both set a flag once they did their first successful run. This way other tools can now if these services completed successfully.

With this change `nodeconfig` also considers a deactivated VPN as a successful run.

Fixes https://github.com/ffbs/gluon-parker/issues/3