### PR TITLE
treewide: Rename gluon-wan to gluon-wan-dns

### DIFF
--- a/ffac-wg-registration/files/lib/gluon/wg-registration/registration.sh
+++ b/ffac-wg-registration/files/lib/gluon/wg-registration/registration.sh
@@ -16,7 +16,7 @@ if [ "$(uci get gluon.mesh_vpn.enabled)" = "true" ] || [ "$(uci get gluon.mesh_v
 		NODENAME=$(uci get system.@system[0].hostname)
 		BROKER=$(uci get wireguard.mesh_vpn.broker)
 		logger -t wg-registration "Post $NODENAME and $PUBLICKEY to $PROTO://$BROKER"
-		if gluon-wan wget -q  -O- --post-data='{"node_name": "'"$NODENAME"'","public_key": "'"$PUBLICKEY"'"}' $PROTO://"$BROKER"
+		if gluon-wan-dns wget -q  -O- --post-data='{"node_name": "'"$NODENAME"'","public_key": "'"$PUBLICKEY"'"}' $PROTO://"$BROKER"
 		then
 			touch /tmp/WG_REGISTRATION_SUCCESSFUL
 			logger -t wg-registration "successfully registered wg publickey"

--- a/ffbs-mesh-vpn-parker/files/etc/init.d/nodeconfig
+++ b/ffbs-mesh-vpn-parker/files/etc/init.d/nodeconfig
@@ -11,7 +11,7 @@ start_service() {
 	sleep 30
 	logger -t nodeconfig:init.d Starting Service
 	procd_open_instance
-	procd_set_param command /usr/bin/gluon-wan /usr/sbin/nodeconfig.sh
+	procd_set_param command /usr/bin/gluon-wan-dns /usr/sbin/nodeconfig.sh
 	procd_set_param respawn
 	procd_set_param stderr 0
 	#procd_set_param limits core="unlimited"  #TODO set ulimit

--- a/ffbs-mesh-vpn-parker/files/usr/sbin/nodeconfig.sh
+++ b/ffbs-mesh-vpn-parker/files/usr/sbin/nodeconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/busybox sh
 # !!!!!!
 # THIS SCRIPT MUST HAVE GID 800 (gluon-mesh-vpn)
-# USE `gluon-wan nodeconfig.sh`
+# USE `gluon-wan-dns nodeconfig.sh`
 # !!!!!!
 SIGN_PUB_KEY=/tmp/ff-Ohb0ba0u/nodeconfig-pub.key
 DEFAULT_SLEEP=20

--- a/ffmuc-mesh-vpn-wireguard-vxlan/shsrc/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/shsrc/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -71,7 +71,7 @@ resolve_host() {
 	local host_to_resolve="$1"
 
 	# older versions of nslookup use "Address 1:" with increasing numbers, newer just use "Address:"
-	if ! all_ips="$(gluon-wan nslookup "$host_to_resolve" | grep '^Address \?[0-9]*:\? ' | sed 's/^Address \?[0-9]*:\? //')"; then
+	if ! all_ips="$(gluon-wan-dns nslookup "$host_to_resolve" | grep '^Address \?[0-9]*:\? ' | sed 's/^Address \?[0-9]*:\? //')"; then
 		logger -p err -t checkuplink "nslookup failed. Unable to get addresses of $host_to_resolve."
 		return 5
 	fi
@@ -103,7 +103,7 @@ resolve_host() {
 }
 
 force_wan_connection() {
-	LD_PRELOAD=libpacketmark.so LIBPACKETMARK_MARK=1 gluon-wan "$@"
+	LD_PRELOAD=libpacketmark.so LIBPACKETMARK_MARK=1 gluon-wan-dns "$@"
 }
 
 is_loadbalancing_enabled() {
@@ -324,7 +324,7 @@ LINKLOCAL="$(interface_linklocal)"
 
 # Add link-address and Peer
 ip address add "${LINKLOCAL}"/64 dev "$MESH_VPN_IFACE"
-gluon-wan wg set "$MESH_VPN_IFACE" peer "$PEER_PUBLICKEY" persistent-keepalive 25 allowed-ips "$PEER_LINKADDRESS/128" endpoint "$PEER_ENDPOINT"
+gluon-wan-dns wg set "$MESH_VPN_IFACE" peer "$PEER_PUBLICKEY" persistent-keepalive 25 allowed-ips "$PEER_LINKADDRESS/128" endpoint "$PEER_ENDPOINT"
 
 # We need to allow incoming vxlan traffic on mesh iface
 sleep 10


### PR DESCRIPTION
> following the respective change in freifunk-gluon/gluon
> 
> 51b6b972c: "mesh-vpn-core: rename gluon-wan to gluon-wan-dns"

This change follows https://github.com/freifunk-gluon/gluon/pull/3547