### PR TITLE
ffbs-mesh-vpn-parker: Implement set_limit in mesh-vpn-provider

### DIFF
--- a/ffbs-mesh-vpn-parker/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/parker.lua
+++ b/ffbs-mesh-vpn-parker/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/parker.lua
@@ -28,4 +28,12 @@ function M.mtu()
 	return site.mesh_vpn.parker.mtu()
 end
 
+function M.set_limit(ingress_limit, egress_limit) -- luacheck: ignore
+	-- In Parker limits have to be applied at runtime since the VPN interfaces
+	-- are dynamically configured during runtime.
+	-- Let's just implement this interface to other scripts can call it without
+	-- raising exceptions.
+end
+
+
 return M


### PR DESCRIPTION
Without this interface `gluon-reconfigure` will raise exceptions, e.g. in `500-mesh-vpn` when applying the limits.

Traffic shaping in parker is applied during runtime when the interfaces are configured in `noderoute.lua`.