### PR TITLE
ffac-ssid-changer: only show offline-ssid settings if a wifi-device is configured

### DIFF
--- a/ff-web-ap-timer/luasrc/lib/gluon/config-mode/controller/admin/ap-timer.lua
+++ b/ff-web-ap-timer/luasrc/lib/gluon/config-mode/controller/admin/ap-timer.lua
@@ -1,2 +1,8 @@
+local uci = require("simple-uci").cursor()
+local wireless = require 'gluon.wireless'
+
 package 'ff-web-ap-timer'
-entry({"admin", "ap-timer"}, model("admin/ap-timer"), _("AP Timer"), 30)
+
+if wireless.device_uses_wlan(uci) then
+	entry({"admin", "ap-timer"}, model("admin/ap-timer"), _("AP Timer"), 30)
+end

--- a/ffac-ssid-changer/luasrc/lib/gluon/config-mode/controller/admin/ssid-changer.lua
+++ b/ffac-ssid-changer/luasrc/lib/gluon/config-mode/controller/admin/ssid-changer.lua
@@ -1,1 +1,8 @@
-entry({"admin", "ssid-changer"}, model("admin/ssid-changer"), _("Offline-SSID"), 35)
+local uci = require("simple-uci").cursor()
+local wireless = require 'gluon.wireless'
+
+package 'ffac-ssid-changer'
+
+if wireless.device_uses_wlan(uci) then
+	entry({"admin", "ssid-changer"}, model("admin/ssid-changer"), _("Offline-SSID"), 35)
+end


### PR DESCRIPTION
The code for this is copied from the gluon `controller/admin/privatewifi.lua` or gluon-web-wifi-config `controller/admin/wifi-config.lua`, which are also only available, if a wifi-device is configure.

closes #172