### PR TITLE
ffac-update-location-gps: add support for other GNSS providers

### DIFF
--- a/ffac-update-location-gps/luasrc/usr/bin/update-location-gps
+++ b/ffac-update-location-gps/luasrc/usr/bin/update-location-gps
@@ -51,8 +51,10 @@ while line_count < max_lines do
 	line_count = line_count + 1  -- Increment the line counter
 
 	local nc = this_line:match("^([^,]+)")
+	local nc_suffix = nc:sub(-3) -- Get the last 3 characters
 
-	if nc == '$GPRMC' then
+	-- support all systems with RMC message
+	if nc_suffix == 'RMC' and nc:sub(1, 1) == '$' then
 		local fields = {}
 		for field in this_line:gmatch("([^,]+)") do
 			table.insert(fields, field)


### PR DESCRIPTION
This adds support for other GNSS providers than GPS.
The following are known:

* GP (GPS)
* GL (GLONASS)
* GA (Galileo)
* GB (BeiDou)
* GQ (QZSS)
* GI (NavIC)
* GN (Combined GNSS)

As all should adhere to the RMC (Recommended Minimum Specific GNSS Data), this should work well.
Tested for GPS and GLONASS.