### PR TITLE
ffac-dsl: add dhcpv6 to dsl setup

### DIFF
--- a/ffac-dsl/luasrc/lib/gluon/upgrade/510-wan-dsl
+++ b/ffac-dsl/luasrc/lib/gluon/upgrade/510-wan-dsl
@@ -17,6 +17,15 @@ if enabled == true then
 		ipv6='auto',
 	})
 
+	uci:section('network','interface','wdsl6',{
+		proto='dhcpv6',
+		ip6table='1',
+		sourcefilter='0',
+		peerdns='0',
+		reqprefix='no',
+		ifname='wdsl',
+	})
+
 	uci:section('firewall','rule','wdsl_dhcpv6',{
 		name = 'DSL DHCPv6',
 		src = 'wdsl',


### PR DESCRIPTION
I remember testing the DSL ipv6 setup on a FB7530, some time ago.
I still had this draft, which I remember to be working well to add ipv6 support on the pppoe interface as well.

But it would be better, if someone tests this again before merging.