### PR TITLE
ffac-private-wan-dhcp: add initial version of uci package and web config

### DIFF
--- a/ffac-private-wan-dhcp/LICENSE
+++ b/ffac-private-wan-dhcp/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2024, Marius Wehrmann
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ffac-private-wan-dhcp/Makefile
+++ b/ffac-private-wan-dhcp/Makefile
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024 Marius Wehrmann
+# SPDX-License-Identifier: BSD-2-Clause
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-private-wan-dhcp
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=BSD-2-Clause
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=bypass FF-Offloading for Direct Network Access for LTE/DSL via Private WAN-Socket
+  DEPENDS:=+uradvd
+endef
+
+define Package/$(PKG_NAME)/description
+  The functionality of this package allows devices connected to a private WAN WiFi to utilize the LTE WAN 
+  connection directly, without the typical redirection or offloading to local network resources. This is 
+  achieved by dynamically managing network routing and gateway settings to ensure that all traffic is 
+  directed through the LTE connection, providing an uninterrupted and low-latency internet experience.
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-private-wan-dhcp/README.md
+++ b/ffac-private-wan-dhcp/README.md
@@ -1,0 +1,7 @@
+# ffac-private-wan-dhcp
+
+This package adds dynamic uci configurations when a cellular or wan interface is made available.
+It can be used to activate and configure a DHCP server on devices which terminate an uplink connection.
+
+On cellular devices, activating the private wlan creates an interface in which no gateway is set by default.
+For this situation, a dhcp server on br-wan is configured through this package.

--- a/ffac-private-wan-dhcp/files/etc/config/private-wan-dhcp
+++ b/ffac-private-wan-dhcp/files/etc/config/private-wan-dhcp
@@ -1,0 +1,6 @@
+config settings 'settings'
+	option enabled '0'
+	option ipaddr '192.168.222.1'
+	option netmask '255.255.255.0'
+	option dns_server '9.9.9.9'
+	list uradvd_dns_server '2620:fe::fe'

--- a/ffac-private-wan-dhcp/files/etc/hotplug.d/iface/40-private-wan-dhcp
+++ b/ffac-private-wan-dhcp/files/etc/hotplug.d/iface/40-private-wan-dhcp
@@ -1,0 +1,11 @@
+ENABLED=$(uci get private-wan-dhcp.settings.enabled)
+
+[ "${ENABLED}" != "1" ] && exit 0
+
+if [ "$INTERFACE" = 'cellular_4' ] || [ "$INTERFACE" = 'cellular' ]; then
+	if [ "${ACTION}" == "ifup" ]; then
+		/lib/gluon/private-wan-dhcp-nat/update.lua up
+	elif [ "${ACTION}" == "ifdown" ]; then
+		/lib/gluon/private-wan-dhcp-nat/update.lua down
+	fi
+fi

--- a/ffac-private-wan-dhcp/luasrc/lib/gluon/private-wan-dhcp-nat/update.lua
+++ b/ffac-private-wan-dhcp/luasrc/lib/gluon/private-wan-dhcp-nat/update.lua
@@ -1,0 +1,198 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+
+-- Funktion zum Ausführen von Shell-Befehlen und Erfassen der Ausgabe
+local function shell(cmd)
+	local f = io.popen(cmd)
+	local result = f:read("*a")
+	f:close()
+	return result
+end
+
+-- Funktion um uradvd config zu prüfen
+
+-- Funktion um zu prüfen, ob eine Regel bereits existiert
+local function uradvd_config_exists(name)
+	local exists = false
+	uci:foreach('uradvd', 'interface', function(iface)
+		if iface.ifname == name then
+			exists = true
+			return false
+		end
+	end)
+	return exists
+end
+
+-- Funktion um uradvd config zu löschen
+local function delete_uradvd_section(name)
+	uci:delete_all('uradvd', 'interface', function(iface)
+		return iface.ifname == name
+	end)
+end
+
+-- Funktion um zu prüfen, ob eine Regel bereits existiert
+local function rule_exists(name)
+	local exists = false
+	uci:foreach('firewall', 'rule', function(section)
+		if section.name == name then
+			exists = true
+			return false
+		end
+	end)
+	return exists
+end
+
+-- Funktion um Regel zu löschen
+local function delete_rule(name)
+	uci:delete_all('firewall', 'rule', function(section)
+		return section.name == name
+	end)
+end
+
+-- Funktion um zu prüfen, ob ein Forwarding bereits existiert
+local function forwarding_exists(src, dest)
+	local exists = false
+	uci:foreach('firewall', 'forwarding', function(section)
+		if section.src == src and section.dest == dest then
+			exists = true
+			return false
+		end
+	end)
+	return exists
+end
+
+-- Funktion um ein forwarding zu löschen
+local function delete_forwarding(src, dest)
+	-- Funktion um Regel zu löschen
+	uci:delete_all('firewall', 'forwarding', function(section)
+		return section.src == src and section.dest == dest
+	end)
+end
+
+if #arg < 1 then
+	io.stderr:write('Usage: update.lua up|down\n')
+	os.exit(1)
+end
+
+local function add_dhcp_config()
+	-- IPv4 für DHCP vergeben auf WAN-Interface
+	local ipaddr = uci:get('private-wan-dhcp','settings','ipaddr')
+	local netmask = uci:get('private-wan-dhcp','settings','netmask')
+	uci:set('network', 'wan', 'proto', 'static')
+	uci:set('network', 'wan', 'ipaddr', ipaddr)
+	uci:set('network', 'wan', 'netmask', netmask)
+	-- IPv6 /64 netzwerk auf cellular anfragen
+	uci:set('network', 'cellular', 'ip6assign', '64')
+
+	uci:save('network')
+
+	os.execute("/etc/init.d/network reload")
+
+	-- Forwarding über das wwan-Interface erlauben
+	uci:set('firewall', '@zone[1]', 'forward', 'ACCEPT')
+
+	-- DHCP in Firewall auf WAN erlauben
+	if not rule_exists('Allow-DHCP-WAN') then
+		uci:add('firewall', 'rule')
+		uci:set('firewall', '@rule[-1]', 'name', 'Allow-DHCP-WAN')
+		uci:set('firewall', '@rule[-1]', 'src', 'wan')
+		uci:set('firewall', '@rule[-1]', 'proto', 'udp')
+		uci:set('firewall', '@rule[-1]', 'src_port', '67 68')
+		uci:set('firewall', '@rule[-1]', 'dest_port', '67 68')
+		uci:set('firewall', '@rule[-1]', 'target', 'ACCEPT')
+	end
+
+	-- DNS in Firewall auf WAN erlauben
+	if not rule_exists('Allow-DNS-WAN') then
+		uci:add('firewall', 'rule')
+		uci:set('firewall', '@rule[-1]', 'name', 'Allow-DNS-WAN')
+		uci:set('firewall', '@rule[-1]', 'src', 'wan')
+		uci:set('firewall', '@rule[-1]', 'proto', 'tcp udp')
+		uci:set('firewall', '@rule[-1]', 'dest_port', '53')
+		uci:set('firewall', '@rule[-1]', 'target', 'ACCEPT')
+	end
+
+	-- NAT von wan auf wwan einrichten
+	if not forwarding_exists('wan', 'wwan') then
+		uci:add('firewall', 'forwarding')
+		uci:set('firewall', '@forwarding[-1]', 'src', 'wan')
+		uci:set('firewall', '@forwarding[-1]', 'dest', 'wwan')
+	end
+
+	uci:save('firewall')
+
+	os.execute("/etc/init.d/firewall reload")
+
+	-- DHCP-Server einstellen für wan
+	uci:delete('dhcp', 'wan', 'ignore')
+	uci:set('dhcp', 'wan', 'start', '100')
+	uci:set('dhcp', 'wan', 'limit', '150')
+	uci:set('dhcp', 'wan', 'leasetime', '12h')
+	uci:set('dhcp', 'wan', 'force', '1')
+	local dns_server = uci:get('private-wan-dhcp','settings','dns_server')
+	uci:set_list('dhcp', 'wan', 'dhcp_option', { '6,'..dns_server })
+	uci:save('dhcp')
+	os.execute("/etc/init.d/dnsmasq reload")
+
+	-- Aktuelles IPv6-Präfix von wwan0 abrufen, doppelte Einträge entfernen
+	local ipv6_prefix_cmd = "ip -6 addr show dev wwan0 | "
+						.. "grep 'global' | "
+						.. "grep -v 'temporary' | "
+						.. "awk '{print $2}' | "
+						.. "cut -f1,2,3,4 -d':' | "
+						.. "sed 's/$/::\\/64/' | "
+						.. "sort | "
+						.. "uniq"
+	local ipv6_prefix = shell(ipv6_prefix_cmd):match("%S+")
+
+	-- Schauen ob Prefix gefunden, falls nein kein IPv6
+	if ipv6_prefix then
+		print("ipv6 prefix is", ipv6_prefix)
+		-- Prüfen, ob eine vorhandene Konfiguration für das Interface 'br-wan' existiert
+		if uradvd_config_exists('br-wan') then
+			delete_uradvd_section('br-wan')
+		end
+
+		local br_wan_section = uci:add('uradvd', 'interface')
+		-- Konfiguration für 'br-wan' aktualisieren
+		uci:set('uradvd', br_wan_section, 'enabled', '1')
+		uci:set('uradvd', br_wan_section, 'ifname', 'br-wan')
+		uci:set('uradvd', br_wan_section, 'default_lifetime', '1800')
+		uci:set_list('uradvd', br_wan_section, 'prefix_on_link', {ipv6_prefix})
+		local uradvd_dns_server = uci:get_list('private-wan-dhcp','settings','uradvd_dns_server')
+		uci:set_list('uradvd', br_wan_section, 'dns', uradvd_dns_server)
+		uci:save('uradvd')
+
+		-- uradvd reload
+		os.execute("/etc/init.d/uradvd reload")
+	end
+end
+
+local function remove_dhcp_config()
+	delete_rule('Allow-DHCP-WAN')
+	delete_rule('Allow-DNS-WAN')
+	delete_forwarding('wan', 'wwan')
+	uci:save('firewall')
+	uci:set('dhcp', 'wan', 'ignore')
+	uci:save('dhcp')
+
+	uci:set('network', 'wan', 'proto', 'dhcp')
+	uci:delete('network', 'wan', 'ipaddr')
+	uci:delete('network', 'wan', 'netmask')
+	uci:save('network')
+	os.execute("/etc/init.d/network reload")
+	os.execute("/etc/init.d/firewall reload")
+	os.execute("/etc/init.d/dnsmasq reload")
+
+	delete_uradvd_section('br-wan')
+	uci:save('uradvd')
+
+	os.execute("/etc/init.d/uradvd reload")
+end
+
+if arg[1] == "up" then
+	add_dhcp_config()
+elseif arg[1] == "down" then
+	remove_dhcp_config()
+end

--- a/ffac-web-private-wan-dhcp/Makefile
+++ b/ffac-web-private-wan-dhcp/Makefile
@@ -1,0 +1,14 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffac-web-private-wan-dhcp
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=gluon-web module to enable and disable ffac-private-wan-dhcp
+  DEPENDS:=+gluon-web-admin +ffac-private-wan-dhcp
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-web-private-wan-dhcp/README.md
+++ b/ffac-web-private-wan-dhcp/README.md
@@ -1,0 +1,12 @@
+# ffac-web-private-wan-dhcp
+
+This package adds configuration options to the config mode to configure ffac-private-wan-dhcp.
+It can be used to activate a DHCP server on devices which terminate an uplink connection.
+
+It allows to set the following:
+
+* enabled
+* ipaddr of the advertised WAN network
+* netmask of the advertised WAN network
+* dns server for IPv4 (advertised with dnsmasq)
+* dns server for IPv6 (advertised with uradvd)

--- a/ffac-web-private-wan-dhcp/i18n/de.po
+++ b/ffac-web-private-wan-dhcp/i18n/de.po
@@ -1,0 +1,21 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2024-07-22 12:00+0100\n"
+"Last-Translator:  <fmaurer@disroot.org>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Enabled"
+msgstr "Aktiviert"
+
+msgid "Private WAN DHCP"
+msgstr "Private WAN DHCP"
+
+msgid "ffac-web-private-wan-dhcp:description"
+msgstr ""
+"Aktiviert eine private WAN-Zone with DHCP und NAT. Das ist für Anschlüsse, die das nicht nativ mitbringen interessant (Mobilfunk oder DSL)"

--- a/ffac-web-private-wan-dhcp/i18n/en.po
+++ b/ffac-web-private-wan-dhcp/i18n/en.po
@@ -1,0 +1,21 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2024-07-22 12:00+0100\n"
+"Last-Translator:  <fmaurer@disroot.org>\n"
+"Language-Team: English\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Enabled"
+msgstr "Enabled"
+
+msgid "Private WAN DHCP"
+msgstr "Private WAN DHCP"
+
+msgid "ffac-web-private-wan-dhcp:description"
+msgstr ""
+"Activates the private WAN with DHCP and NAT. This is relevant for cellular or dsl uplinks"

--- a/ffac-web-private-wan-dhcp/i18n/ffac-web-private-wan-dhcp.pot
+++ b/ffac-web-private-wan-dhcp/i18n/ffac-web-private-wan-dhcp.pot
@@ -1,0 +1,11 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "Enabled"
+msgstr ""
+
+msgid "Private WAN DHCP"
+msgstr ""
+
+msgid "ffac-web-private-wan-dhcp:description"
+msgstr ""

--- a/ffac-web-private-wan-dhcp/luasrc/lib/gluon/config-mode/controller/admin/ffac_private_wan_dhcp.lua
+++ b/ffac-web-private-wan-dhcp/luasrc/lib/gluon/config-mode/controller/admin/ffac_private_wan_dhcp.lua
@@ -1,0 +1,3 @@
+package 'ffac-web-private-wan-dhcp'
+
+entry({"admin", "ffac_private_wan_dhcp"}, model("admin/ffac_private_wan_dhcp"), _("Private WAN DHCP"), 50)

--- a/ffac-web-private-wan-dhcp/luasrc/lib/gluon/config-mode/model/admin/ffac_private_wan_dhcp.lua
+++ b/ffac-web-private-wan-dhcp/luasrc/lib/gluon/config-mode/model/admin/ffac_private_wan_dhcp.lua
@@ -1,0 +1,31 @@
+local uci = require("simple-uci").cursor()
+
+local f = Form(translate("Private WAN DHCP"))
+
+local s = f:section(Section, nil, translate('ffac-web-private-wan-dhcp:description'))
+
+local enabled = s:option(Flag, "enabled", translate("Enabled"))
+enabled.default = uci:get_bool('private-wan-dhcp', 'settings', 'enabled', false)
+
+local ipaddr = s:option(Value, "ipaddr", translate("IP address"))
+ipaddr.default = uci:get('private-wan-dhcp', 'settings', 'ipaddr', '192.168.222.1')
+
+local netmask = s:option(Value, "netmask", translate("Netmask"))
+netmask.default = uci:get('private-wan-dhcp', 'settings', 'netmask', '255.255.255.0')
+
+local dns_server = s:option(Value, "dns_server", translate("Static DNS servers") ..  ' ' ..translate("IPv4"))
+dns_server.default = uci:get('private-wan-dhcp', 'settings', 'dns_server', '9.9.9.9')
+
+local uradvd_dns_server = s:option(Value, "dns_server", translate("Static DNS servers") .. ' ' .. translate("IPv6"))
+uradvd_dns_server.default = uci:get('private-wan-dhcp', 'settings', 'uradvd_dns_server', '9.9.9.9')
+
+function f:write()
+	uci:set('private-wan-dhcp', 'settings', 'enabled', enabled.data)
+	uci:set('private-wan-dhcp', 'settings', 'ipaddr', ipaddr.data)
+	uci:set('private-wan-dhcp', 'settings', 'netmask', netmask.data)
+	uci:set('private-wan-dhcp', 'settings', 'dns_server', dns_server.data)
+	uci:set_list('private-wan-dhcp', 'settings', 'uradvd_dns_server', { uradvd_dns_server.data })
+	uci:commit('private-wan-dhcp')
+end
+
+return f


### PR DESCRIPTION
Add two new packages, which help using private-wlan with cellular, DSL interfaces or bridge mode devices.

## ffac-private-wan-dhcp
This package adds dynamic uci configurations when a cellular or wan interface is made available.
It can be used to activate and configure a DHCP server on devices which terminate an uplink connection.

On cellular devices, activating the private wlan creates an interface in which no gateway is set by default.
For this situation, a dhcp server on br-wan is configured through this package.

## ffac-web-private-wan-dhcp
This package adds configuration options to the config mode to configure ffac-private-wan-dhcp.
It can be used to activate a DHCP server on devices which terminate an uplink connection.
