### PR TITLE
adapt new pubkey_privacy function to provider API

### DIFF
--- a/ff-mesh-vpn-tunneldigger/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/tunneldigger.lua
+++ b/ff-mesh-vpn-tunneldigger/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/tunneldigger.lua
@@ -43,4 +43,9 @@ function M.mtu()
 	return site.mesh_vpn.tunneldigger.mtu()
 end
 
+function M.pubkey_privacy()
+	-- pubkey_privacy is not needed as no key exists
+	return false
+end
+
 return M

--- a/ffbs-mesh-vpn-parker/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/parker.lua
+++ b/ffbs-mesh-vpn-parker/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/parker.lua
@@ -35,5 +35,10 @@ function M.set_limit(ingress_limit, egress_limit) -- luacheck: ignore
 	-- raising exceptions.
 end
 
+function M.pubkey_privacy()
+	-- pubkey_privacy is not needed as parker uses wireguard
+	return false
+end
+
 
 return M

--- a/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -43,4 +43,9 @@ function M.mtu()
 	return site.mesh_vpn.wireguard.mtu()
 end
 
+function M.pubkey_privacy()
+	-- wireguard does not need pubkey_privacy
+	return false
+end
+
 return M


### PR DESCRIPTION
This is relevant for the upcoming gluon release

Relevant change once https://github.com/freifunk-gluon/gluon/pull/3625 is merged.

The gluon PR extends the provider protocol to also enable hiding the pubkey using `pubkey_privacy()` method.
This must be handled by our community-protocols as well.