### PR TITLE
ffda-network-setup-mode: Add support for Sophos AP15

### DIFF
--- a/ffda-network-setup-mode/luasrc/usr/lib/lua/gluon/network-setup-mode.lua
+++ b/ffda-network-setup-mode/luasrc/usr/lib/lua/gluon/network-setup-mode.lua
@@ -4,11 +4,14 @@ local platform = require 'gluon.platform'
 local M = {}
 
 function M.supports_networked_activation()
-	if platform.match('ramips', 'mt7621', {
-		'zyxel,nwa55axe',
-	}) then
-		return true
-	end
+    return
+        platform.match('ramips', 'mt7621', {
+            'zyxel,nwa55axe',
+        })
+        or
+        platform.match('ath79', 'generic', {
+            'sophos,ap15',
+        })
 end
 
 return M


### PR DESCRIPTION
Added support for Sophos AP15