### PR TITLE
ffac-private-wan-dhcp: route clients' IPv6 over LTE correctly

### DIFF
--- a/ffac-private-wan-dhcp/Makefile
+++ b/ffac-private-wan-dhcp/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffac-private-wan-dhcp
-PKG_VERSION:=1.0
+PKG_VERSION:=1.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-2-Clause
@@ -16,10 +16,14 @@ define Package/$(PKG_NAME)
 endef
 
 define Package/$(PKG_NAME)/description
-  The functionality of this package allows devices connected to a private WAN WiFi to utilize the LTE WAN 
-  connection directly, without the typical redirection or offloading to local network resources. This is 
-  achieved by dynamically managing network routing and gateway settings to ensure that all traffic is 
+  The functionality of this package allows devices connected to a private WAN WiFi to utilize the LTE WAN
+  connection directly, without the typical redirection or offloading to local network resources. This is
+  achieved by dynamically managing network routing and gateway settings to ensure that all traffic is
   directed through the LTE connection, providing an uninterrupted and low-latency internet experience.
+
+  Includes IPv6 support: the LTE /64 is advertised to private WAN clients via uradvd and an IPv6
+  policy-routing rule (rule6) sends their traffic through the LTE routing table instead of the
+  Freifunk default route. The rule is (re)created with the current prefix on every uplink ifup.
 endef
 
 $(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffac-private-wan-dhcp/README.md
+++ b/ffac-private-wan-dhcp/README.md
@@ -1,7 +1,32 @@
 # ffac-private-wan-dhcp
 
-This package adds dynamic uci configurations when a cellular or wan interface is made available.
-It can be used to activate and configure a DHCP server on devices which terminate an uplink connection.
+Allows devices connected to a private WAN WiFi (terminating an LTE/DSL uplink) to
+use that uplink directly instead of being offloaded into the Freifunk mesh.
 
-On cellular devices, activating the private wlan creates an interface in which no gateway is set by default.
-For this situation, a dhcp server on br-wan is configured through this package.
+On `ifup` of the cellular uplink (`cellular` / `cellular_4`) it:
+
+* switches the `wan` interface to a static IPv4 net and runs a DHCP server on it
+  (range, lease, DNS configurable via `/etc/config/private-wan-dhcp`),
+* sets up firewall rules + NAT (`wan` → `wwan`) so IPv4 clients reach the internet,
+* requests a `/64` on the cellular interface, derives the current global IPv6 /64
+  from `wwan0` and advertises it to the private WAN clients via **uradvd** on `br-wan`,
+* **adds an IPv6 policy-routing rule** (`network.lte_clients`, a `rule6`) that sends
+  traffic from that /64 into the LTE routing table (lookup `1`, priority `9999`).
+  Without it the clients' IPv6 traffic falls back to the `main` table, whose
+  default route points at Freifunk — so they would get an address but no internet.
+
+The IPv6 rule is recreated with the *current* prefix on every uplink `ifup`, so it
+survives provider prefix changes automatically. On `ifdown` all of the above
+(including the rule) is reverted.
+
+## Config options (`/etc/config/private-wan-dhcp`)
+
+* `enabled` — master switch (`0`/`1`)
+* `ipaddr` / `netmask` — advertised private WAN IPv4 network
+* `dns_server` — IPv4 DNS advertised via dnsmasq
+* `uradvd_dns_server` — IPv6 DNS advertised via uradvd (list)
+
+> Why NAT-free routing works for IPv6: the cellular uplink (`wwan0`) is a
+> point-to-point link and the mobile network routes the whole /64 to the device
+> (3GPP / RFC 7278). The /64 can therefore be handed to clients and routed
+> directly — no NAT66 or NDP proxy required.

--- a/ffac-private-wan-dhcp/luasrc/lib/gluon/private-wan-dhcp-nat/update.lua
+++ b/ffac-private-wan-dhcp/luasrc/lib/gluon/private-wan-dhcp-nat/update.lua
@@ -166,6 +166,21 @@ local function add_dhcp_config()
 
 		-- uradvd reload
 		os.execute("/etc/init.d/uradvd reload")
+
+		-- IPv6-Policy-Routing: Traffic der br-wan-Clients aus dem LTE-/64 ueber
+		-- Tabelle 1 (LTE-Default via wwan0) leiten. Ohne diese Regel faellt der
+		-- Client-Traffic auf Tabelle 'main' zurueck -> dort zeigt die v6-Default-
+		-- Route auf Freifunk (br-client), und die Clients kommen nicht ueber LTE raus.
+		-- Die Section wird mit dem AKTUELLEN Praefix neu gesetzt; da dieses Skript
+		-- bei jedem 'ifup' der LTE-Schnittstelle laeuft, ist die Regel praefix-sicher.
+		uci:delete('network', 'lte_clients')
+		uci:section('network', 'rule6', 'lte_clients', {
+			src = ipv6_prefix,
+			lookup = '1',
+			priority = '9999',
+		})
+		uci:save('network')
+		os.execute("/etc/init.d/network reload")
 	end
 end
 
@@ -177,6 +192,9 @@ local function remove_dhcp_config()
 	uci:set('dhcp', 'wan', 'ignore')
 	uci:save('dhcp')
 
+	-- IPv6-Policy-Routing-Regel wieder entfernen
+	uci:delete('network', 'lte_clients')
+
 	uci:set('network', 'wan', 'proto', 'dhcp')
 	uci:delete('network', 'wan', 'ipaddr')
 	uci:delete('network', 'wan', 'netmask')
@@ -184,6 +202,9 @@ local function remove_dhcp_config()
 	os.execute("/etc/init.d/network reload")
 	os.execute("/etc/init.d/firewall reload")
 	os.execute("/etc/init.d/dnsmasq reload")
+
+	-- evtl. noch live haengende Regel (Prio 9999) sicher abraeumen
+	os.execute("while ip -6 rule del priority 9999 2>/dev/null; do :; done")
 
 	delete_uradvd_section('br-wan')
 	uci:save('uradvd')

--- a/ffac-web-private-wan-dhcp/Makefile
+++ b/ffac-web-private-wan-dhcp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffac-web-private-wan-dhcp
 PKG_VERSION:=1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(TOPDIR)/../package/gluon.mk
 

--- a/ffac-web-private-wan-dhcp/luasrc/lib/gluon/config-mode/model/admin/ffac_private_wan_dhcp.lua
+++ b/ffac-web-private-wan-dhcp/luasrc/lib/gluon/config-mode/model/admin/ffac_private_wan_dhcp.lua
@@ -16,8 +16,9 @@ netmask.default = uci:get('private-wan-dhcp', 'settings', 'netmask', '255.255.25
 local dns_server = s:option(Value, "dns_server", translate("Static DNS servers") ..  ' ' ..translate("IPv4"))
 dns_server.default = uci:get('private-wan-dhcp', 'settings', 'dns_server', '9.9.9.9')
 
-local uradvd_dns_server = s:option(Value, "dns_server", translate("Static DNS servers") .. ' ' .. translate("IPv6"))
-uradvd_dns_server.default = uci:get('private-wan-dhcp', 'settings', 'uradvd_dns_server', '9.9.9.9')
+local uradvd_dns_server = s:option(Value, "uradvd_dns_server",
+	translate("Static DNS servers") .. ' ' .. translate("IPv6"))
+uradvd_dns_server.default = uci:get('private-wan-dhcp', 'settings', 'uradvd_dns_server', '2620:fe::fe')
 
 function f:write()
 	uci:set('private-wan-dhcp', 'settings', 'enabled', enabled.data)


### PR DESCRIPTION
- update.lua: on uplink up, add an IPv6 policy-routing rule (network.lte_clients, a rule6) that sends the LTE /64 clients into the LTE routing table (lookup 1, priority 9999), using the prefix already derived from wwan0; removed on down. Fixes clients getting an IPv6 address but no connectivity (their traffic fell back to the Freifunk default route).

ffac-web-private-wan-dhcp: fix the IPv6 DNS field reusing the dns_server option id (now uradvd_dns_server).