### PR TITLE
ffmuc-leds-off: add package

### DIFF
--- a/ffmuc-leds-off/Makefile
+++ b/ffmuc-leds-off/Makefile
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffmuc-leds-off
+PKG_VERSION:=1
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+include $(TOPDIR)/../package/gluon.mk
+
+define Package/$(PKG_NAME)
+  TITLE:=Disable all LEDs during normal operation
+  DEPENDS:=+gluon-core
+endef
+
+define Package/$(PKG_NAME)/conffiles
+/etc/config/leds-off
+endef
+
+define Package/$(PKG_NAME)/description
+  Darkens all LEDs after the boot sequence completes (S99, after
+  set_state done at S95). Intended for nodes deployed in dark
+  environments or where visible LEDs would expose the device to
+  onlookers. LEDs follow their normal patterns during preinit, boot,
+  sysupgrade, and setup mode so error and progress signals stay
+  debuggable. Disabled by default; enable per-node with
+  `uci set leds-off.settings.enabled='1' && gluon-reconfigure`.
+endef
+
+$(eval $(call BuildPackageGluon,$(PKG_NAME)))

--- a/ffmuc-leds-off/README.md
+++ b/ffmuc-leds-off/README.md
@@ -1,0 +1,60 @@
+# ffmuc-leds-off
+
+This package lets node operators turn off **all LEDs** during normal operation,
+for nodes deployed in dark environments or where the LEDs would expose the
+device to onlookers.
+
+Errors and warnings remain visible because their existing LED behaviour is
+untouched:
+
+- **Setup / config mode** — the device still blinks its status LED so users
+  can find a misconfigured node.
+- **Sysupgrade in progress** — the OpenWrt diagnostic LED pattern fires
+  normally, so users see the upgrade is running and won't power-off the
+  device mid-flash.
+- **Boot in progress (preinit)** — LEDs run their normal patterns until the
+  device finishes booting. Only after `set_state done` (S95) does this package
+  darken them (S99).
+
+## Configuration
+
+The package is **disabled by default** after install. To darken the LEDs on
+a node:
+
+```sh
+uci set leds-off.settings.enabled='1'
+uci commit leds-off
+gluon-reconfigure                # registers the S99 init.d service
+/etc/init.d/leds-off restart     # apply immediately (or reboot)
+```
+
+To restore default LED behaviour:
+
+```sh
+uci set leds-off.settings.enabled='0'
+uci commit leds-off
+gluon-reconfigure                # unregisters the S99 init.d service
+/etc/init.d/leds-off stop        # best-effort restore now (or reboot)
+```
+
+A reboot is the safest way to restore LEDs whose default triggers come from
+kernel device tree (DTS) and aren't tracked in `/etc/config/system`.
+
+## How it works
+
+When `enabled='1'`, an init script at `/etc/init.d/leds-off` (START=99,
+i.e. *after* OpenWrt's `set_state done` at S95) iterates every entry under
+`/sys/class/leds/` and sets:
+
+- `trigger` → `none`
+- `brightness` → `0`
+
+This affects only software-controllable LEDs. LEDs wired directly to PHY
+chips (some RJ45 link/activity indicators) cannot be turned off in software
+and are unaffected by this package.
+
+If the device is in setup mode (`gluon-setup-mode.@setup_mode[0].configured`
+is not `1`), the darkening step is skipped so the setup-mode blink pattern
+remains visible. In practice, setup mode runs a different init path
+(`/lib/gluon/setup-mode/init.d/`) entirely, so the standard `/etc/init.d/leds-off`
+wouldn't fire there anyway — the check is defence-in-depth.

--- a/ffmuc-leds-off/files/etc/config/leds-off
+++ b/ffmuc-leds-off/files/etc/config/leds-off
@@ -1,0 +1,2 @@
+config settings 'settings'
+	option enabled '0'

--- a/ffmuc-leds-off/files/etc/init.d/leds-off
+++ b/ffmuc-leds-off/files/etc/init.d/leds-off
@@ -1,0 +1,36 @@
+#!/bin/sh /etc/rc.common
+# /etc/rc.common imports this script and uses variables defined here
+# shellcheck disable=SC2034
+# shellcheck shell="busybox sh"
+
+# Must run after /etc/init.d/done (S95), which calls `set_state done`
+# and would otherwise re-light LEDs after we darken them.
+START=99
+STOP=10
+
+start() {
+	local enabled
+	config_load 'leds-off'
+	config_get_bool enabled settings enabled 0
+
+	[ "$enabled" = 1 ] || return 0
+
+	# Defense-in-depth: setup mode uses a different init path, so this
+	# normally won't run there anyway.
+	local configured
+	configured="$(uci -q get 'gluon-setup-mode.@setup_mode[0].configured')"
+	[ "$configured" = 1 ] || return 0
+
+	local led
+	for led in /sys/class/leds/*; do
+		[ -e "$led/trigger" ] || continue
+		echo none > "$led/trigger" 2>/dev/null
+		[ -e "$led/brightness" ] && echo 0 > "$led/brightness" 2>/dev/null
+	done
+}
+
+stop() {
+	# Best-effort restore: re-apply OpenWrt's UCI LED config. LEDs whose
+	# defaults come from kernel DTS triggers may need a reboot to fully restore.
+	/etc/init.d/led restart >/dev/null 2>&1
+}

--- a/ffmuc-leds-off/luasrc/lib/gluon/upgrade/520-leds-off
+++ b/ffmuc-leds-off/luasrc/lib/gluon/upgrade/520-leds-off
@@ -1,0 +1,9 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+
+if uci:get_bool('leds-off', 'settings', 'enabled') then
+	os.execute('/etc/init.d/leds-off enable')
+else
+	os.execute('/etc/init.d/leds-off disable')
+end


### PR DESCRIPTION
Add a package that lets node operators darken all LEDs during normal operation, intended for nodes deployed in dark environments or where visible LEDs would expose the device to onlookers.

LEDs follow their normal patterns throughout the boot sequence (preinit, regular, set_state done at S95) and during sysupgrade and setup mode, so error and progress signals stay debuggable. Only after S99 are LEDs darkened by iterating /sys/class/leds/* and setting each trigger to "none" and brightness to 0.

The package is disabled by default. To enable:
```
uci set leds-off.settings.enabled='1'
uci commit leds-off
gluon-reconfigure
/etc/init.d/leds-off restart   # or reboot
```
Setup mode is detected via gluon-setup-mode.@setup_mode[0].configured and skipped as defense-in-depth, even though it runs a separate init path that would not invoke this script anyway.