### PR TITLE
ffgraz-web-model: escape certificate CN in config-mode info view

### DIFF
--- a/ffgraz-web-model/files/lib/gluon/web/view/model/info.html
+++ b/ffgraz-web-model/files/lib/gluon/web/view/model/info.html
@@ -5,11 +5,11 @@
 	attr("data-depends", self:deplist(self.deps))
 %>>
 	<%- if self.content then -%>
-	<%= self.content %>
+	<%| self.content %>
 	<%- else -%>
 	<label class="gluon-value-title"><%=self.title%></label>
 
-	<span class="gluon-value-field"><%=self.description%></span>
+	<span class="gluon-value-field"><%|self.description%></span>
 	<%- end -%>
 </div>
 <%- end -%>


### PR DESCRIPTION
The Mesh VPN config-mode page displays the Subject/Issuer CN of uploaded X.509 certificates without HTML-escaping (`info.html` used the raw `<%= %>` template operator). A crafted certificate with a CN like `<script>...</script>` gets persistently reflected on every later visit to the Mesh VPN page.

Fixed by using the proper escaping template operator