### PR TITLE
ffgraz-ddhcpd-batman-adv: fix shell injection via mesh-supplied gateway address

### DIFF
--- a/ffgraz-ddhcpd-batman-adv/files/usr/sbin/ddhcpd-gateway-update
+++ b/ffgraz-ddhcpd-batman-adv/files/usr/sbin/ddhcpd-gateway-update
@@ -73,7 +73,10 @@ fi
 
 for _ in $(seq "$GW_UPDATE_TRIES"); do
 	gwaddr="$(get_gw_ipv4_address "$gwmac")"
-	[ -n "$gwaddr" ] && break
+	if echo "$gwaddr" | grep -E -q '^(([0-9]){1,3}\.){3}[0-9]{1,3}$'; then
+		break
+	fi
+	gwaddr=""
 done
 
 if [ -z "$gwaddr" ] && [ ! "$gwmac" = "$last_gwmac" ]; then


### PR DESCRIPTION
`ddhcpd-gateway-update` reads the current gateway's IPv4 address from a respondd JSON reply received over the mesh network and writes it unvalidated into `/tmp/ddhcp_gw_cache`, which is later `.`-sourced as shell code once a minute via cron. Any node that gets elected as batman-adv gateway can return an arbitrary string in that field, letting it run shell commands as root on every node that picks it as gateway.

Implemented a fix to validate the received address against a strict IPv4 pattern immediately after receiving it.